### PR TITLE
Authorino: Fix deployment

### DIFF
--- a/authorinomanifests/authorino.yaml
+++ b/authorinomanifests/authorino.yaml
@@ -1,19 +1,9 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    app: authorino
-    control-plane: controller-manager
-  name: kuadrant-system
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
-  labels:
-    app: authorino
   name: services.config.authorino.3scale.net
 spec:
   group: config.authorino.3scale.net
@@ -24,36 +14,51 @@ spec:
     singular: service
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Ready?
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - description: Number of identity verification policies
+      jsonPath: .status.numIdentityPolicies
+      name: Id policies
+      priority: 2
+      type: integer
+    - description: Number of metadata policies
+      jsonPath: .status.numMetadataPolicies
+      name: Metadata policies
+      priority: 2
+      type: integer
+    - description: Number of authorization policies
+      jsonPath: .status.numAuthorizationPolicies
+      name: Authz policies
+      priority: 2
+      type: integer
+    - description: Whether issuing Festival Wristbands
+      jsonPath: .status.festivalWristbandEnabled
+      name: Wristband
+      priority: 2
+      type: boolean
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Service is the schema for Authorino's services API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Specifies the desired state of the Service resource, i.e.
-              the authencation/authorization scheme to be applied to protect the matching
-              HTTP services.
+            description: Specifies the desired state of the Service resource, i.e. the authencation/authorization scheme to be applied to protect the matching HTTP services.
             properties:
               authorization:
-                description: Authorization is the list of authorization policies.
-                  All policies in this list MUST evaluate to "true" for a request
-                  be successful in the authorization phase.
+                description: Authorization is the list of authorization policies. All policies in this list MUST evaluate to "true" for a request be successful in the authorization phase.
                 items:
-                  description: 'Authorization policy to be enforced. Apart from "name",
-                    one of the following parameters is required and only one of the
-                    following parameters is allowed: "opa" or "json".'
+                  description: 'Authorization policy to be enforced. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa" or "json".'
                   oneOf:
                   - properties:
                       name: {}
@@ -72,17 +77,11 @@ spec:
                       description: JSON pattern matching authorization policy.
                       properties:
                         conditions:
-                          description: Conditions that must match for Authorino to
-                            enforce this policy; otherwise, the policy will be skipped.
+                          description: Conditions that must match for Authorino to enforce this policy; otherwise, the policy will be skipped.
                           items:
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to
-                                  the content fetched from the authorization JSON,
-                                  for comparison with "value". Possible values are:
-                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
-                                  for arrays), "excl" (excludes; for arrays), "matches"
-                                  (regex)'
+                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -91,16 +90,10 @@ spec:
                                 - matches
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                                  The value is used to fetch content from the input
-                                  authorization JSON built by Authorino along the
-                                  identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison
-                                  with the content fetched from the authorization
-                                  policy. If used with the "matches" operator, the
-                                  value must compile to a valid Golang regex.
+                                description: The value of reference for the comparison with the content fetched from the authorization policy. If used with the "matches" operator, the value must compile to a valid Golang regex.
                                 type: string
                             required:
                             - operator
@@ -109,17 +102,11 @@ spec:
                             type: object
                           type: array
                         rules:
-                          description: The rules that must all evaluate to "true"
-                            for the request to be authorized.
+                          description: The rules that must all evaluate to "true" for the request to be authorized.
                           items:
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to
-                                  the content fetched from the authorization JSON,
-                                  for comparison with "value". Possible values are:
-                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
-                                  for arrays), "excl" (excludes; for arrays), "matches"
-                                  (regex)'
+                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -128,16 +115,10 @@ spec:
                                 - matches
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                                  The value is used to fetch content from the input
-                                  authorization JSON built by Authorino along the
-                                  identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison
-                                  with the content fetched from the authorization
-                                  policy. If used with the "matches" operator, the
-                                  value must compile to a valid Golang regex.
+                                description: The value of reference for the comparison with the content fetched from the authorization policy. If used with the "matches" operator, the value must compile to a valid Golang regex.
                                 type: string
                             required:
                             - operator
@@ -153,11 +134,7 @@ spec:
                       description: Open Policy Agent (OPA) authorization policy.
                       properties:
                         inlineRego:
-                          description: Authorization policy as a Rego language document.
-                            The Rego document must include the "allow" condition,
-                            set by Authorino to "false" by default (i.e. requests
-                            are unauthorized unless changed). The Rego document must
-                            NOT include the "package" declaration in line 1.
+                          description: Authorization policy as a Rego language document. The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed). The Rego document must NOT include the "package" declaration in line 1.
                           type: string
                       type: object
                   required:
@@ -165,22 +142,14 @@ spec:
                   type: object
                 type: array
               hosts:
-                description: The list of public host names of the HTTP services protected
-                  by this authentication/authorization scheme. Authorino uses the
-                  requested host to lookup for the corresponding authentication/authorization
-                  configs to enforce.
+                description: The list of public host names of the HTTP services protected by this authentication/authorization scheme. Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
                 items:
                   type: string
                 type: array
               identity:
-                description: List of identity sources/authentication modes. At least
-                  one config of this list MUST evaluate to a valid identity for a
-                  request to be successful in the identity verification phase.
+                description: List of identity sources/authentication modes. At least one config of this list MUST evaluate to a valid identity for a request to be successful in the identity verification phase.
                 items:
-                  description: 'The identity source/authentication mode config. Apart
-                    from "name", one of the following parameters is required and only
-                    one of the following parameters is allowed: "oicd", "apiKey" or
-                    "kubernetes".'
+                  description: 'The identity source/authentication mode config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "oicd", "apiKey" or "kubernetes".'
                   oneOf:
                   - properties:
                       credentials: {}
@@ -216,25 +185,17 @@ spec:
                         labelSelectors:
                           additionalProperties:
                             type: string
-                          description: The map of label selectors used by Authorino
-                            to match secrets from the cluster storing valid credentials
-                            to authenticate to this service
+                          description: The map of label selectors used by Authorino to match secrets from the cluster storing valid credentials to authenticate to this service
                           type: object
                       required:
                       - labelSelectors
                       type: object
                     credentials:
-                      description: Defines where client credentials are required to
-                        be passed in the request for this identity source/authentication
-                        mode. If omitted, it defaults to client credentials passed
-                        in the HTTP Authorization header and the "Bearer" prefix expected
-                        prepended to the credentials value (token, API key, etc).
+                      description: Defines where client credentials are required to be passed in the request for this identity source/authentication mode. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
                       properties:
                         in:
                           default: authorization_header
-                          description: The location in the request where client credentials
-                            shall be passed on requests authenticating with this identity
-                            source/authentication mode.
+                          description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
                           enum:
                           - authorization_header
                           - custom_header
@@ -242,13 +203,7 @@ spec:
                           - cookie
                           type: string
                         keySelector:
-                          description: Used in conjunction with the `in` parameter.
-                            When used with `authorization_header`, the value is the
-                            prefix of the client credentials string, separated by
-                            a white-space, in the HTTP Authorization header (e.g.
-                            "Bearer", "Basic"). When used with `custom_header`, `query`
-                            or `cookie`, the value is the name of the HTTP header,
-                            query string parameter or cookie key, respectively.
+                          description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                           type: string
                       required:
                       - keySelector
@@ -256,40 +211,28 @@ spec:
                     kubernetes:
                       properties:
                         audiences:
-                          description: The list of audiences (scopes) that must be
-                            claimed in a Kubernetes authentication token supplied
-                            in the request, and reviewed by Authorino. If omitted,
-                            Authorino will review tokens expecting the host name of
-                            the requested protected service amongst the audiences.
+                          description: The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino. If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.
                           items:
                             type: string
                           type: array
                       type: object
                     name:
-                      description: The name of this identity source/authentication
-                        mode. It usually identifies a source of identities or group
-                        of users/clients of the protected service. It may as well
-                        be used for this identity config to be referred in some metadata
-                        configs.
+                      description: The name of this identity source/authentication mode. It usually identifies a source of identities or group of users/clients of the protected service. It may as well be used for this identity config to be referred in some metadata configs.
                       type: string
                     oauth2:
                       properties:
                         credentialsRef:
-                          description: Reference to a Kubernetes secret in the same
-                            namespace, that stores client credentials to the OAuth2
-                            server.
+                          description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the OAuth2 server.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                         tokenIntrospectionUrl:
                           description: The full URL of the token introspection endpoint.
                           type: string
                         tokenTypeHint:
-                          description: The token type hint for the token introspection.
-                            If omitted, it defaults to "access_token".
+                          description: The token type hint for the token introspection. If omitted, it defaults to "access_token".
                           type: string
                       required:
                       - credentialsRef
@@ -298,14 +241,7 @@ spec:
                     oidc:
                       properties:
                         endpoint:
-                          description: Endpoint of the OIDC issuer. Authorino will
-                            append to this value the well-known path to the OpenID
-                            Connect discovery endpoint (i.e. "/.well-known/openid-configuration"),
-                            used to automatically discover the OpenID Connect configuration,
-                            whose set of claims is expected to include (among others)
-                            the "jkws_uri" claim. The value must coincide with the
-                            value of  the "iss" (issuer) claim of the discovered OpenID
-                            Connect configuration.
+                          description: Endpoint of the OIDC issuer. Authorino will append to this value the well-known path to the OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"), used to automatically discover the OpenID Connect configuration, whose set of claims is expected to include (among others) the "jkws_uri" claim. The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
                           type: string
                       required:
                       - endpoint
@@ -315,12 +251,9 @@ spec:
                   type: object
                 type: array
               metadata:
-                description: List of metadata source configs. Authorino fetches JSON
-                  content from sources on this list on every request.
+                description: List of metadata source configs. Authorino fetches JSON content from sources on this list on every request.
                 items:
-                  description: 'The metadata config. Apart from "name", one of the
-                    following parameters is required and only one of the following
-                    parameters is allowed: "userInfo" or "uma".'
+                  description: 'The metadata config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "userInfo" or "uma".'
                   oneOf:
                   - properties:
                       name: {}
@@ -334,41 +267,85 @@ spec:
                     required:
                     - name
                     - uma
+                  - properties:
+                      name: {}
+                      uma: {}
+                    required:
+                    - name
+                    - http
                   properties:
+                    http:
+                      description: Generic HTTP interface to obtain authorization metadata from a HTTP service.
+                      properties:
+                        credentials:
+                          description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          properties:
+                            in:
+                              default: authorization_header
+                              description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
+                              enum:
+                              - authorization_header
+                              - custom_header
+                              - query
+                              - cookie
+                              type: string
+                            keySelector:
+                              description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
+                              type: string
+                          required:
+                          - keySelector
+                          type: object
+                        endpoint:
+                          description: Endpoint of the HTTP service. The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
+                          type: string
+                        method:
+                          description: 'HTTP verb used in the request to the service. Accepted values: GET (default), POST. When the request method is POST, the authorization JSON is passed in the body of the request.'
+                          enum:
+                          - GET
+                          - POST
+                          type: string
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - endpoint
+                      - sharedSecretRef
+                      type: object
                     name:
-                      description: The name of the metadata source. Policies of te
-                        authorization phase can refer to this metadata by this value.
+                      description: The name of the metadata source. Policies of te authorization phase can refer to this metadata by this value.
                       type: string
                     uma:
                       description: User-Managed Access (UMA) source of resource data.
                       properties:
                         credentialsRef:
-                          description: Reference to a Kubernetes secret in the same
-                            namespace, that stores client credentials to the resource
-                            registration API of the UMA server.
+                          description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the resource registration API of the UMA server.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                         endpoint:
-                          description: The endpoint of the UMA server. The value must
-                            coincide with the "issuer" claim of the UMA config discovered
-                            from the well-known uma configuration endpoint.
+                          description: The endpoint of the UMA server. The value must coincide with the "issuer" claim of the UMA config discovered from the well-known uma configuration endpoint.
                           type: string
                       required:
                       - credentialsRef
                       - endpoint
                       type: object
                     userInfo:
-                      description: OpendID Connect UserInfo linked to an OIDC identity
-                        config of this same spec.
+                      description: OpendID Connect UserInfo linked to an OIDC identity config of this same spec.
                       properties:
                         identitySource:
-                          description: The name of an OIDC identity source included
-                            in the "identity" section and whose OpenID Connect configuration
-                            discovered includes the OIDC "userinfo_endpoint" claim.
+                          description: The name of an OIDC identity source included in the "identity" section and whose OpenID Connect configuration discovered includes the OIDC "userinfo_endpoint" claim.
                           type: string
                       required:
                       - identitySource
@@ -377,15 +354,87 @@ spec:
                   - name
                   type: object
                 type: array
+              wristband:
+                description: Wristband is the opt-in configuration for issuing Authorino Festival Wristband tokens at the end of the auth pipeline.
+                properties:
+                  customClaims:
+                    description: Any claims to be added to the wristband token apart from the standard JWT claims (iss, iat, exp) added by default.
+                    items:
+                      properties:
+                        name:
+                          description: The name of the claim
+                          type: string
+                        value:
+                          description: Static value of the claim
+                          type: string
+                        valueFrom:
+                          description: Dynamic value of the claim
+                          properties:
+                            authJSON:
+                              description: Selector to fill the value of claim from the authorization JSON
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  issuer:
+                    description: 'The endpoint to the Authorino service that issues the wristband (format: <scheme>://<host>:<port>/<realm>, where <realm> = <namespace>/<authorino-service-resource-name)'
+                    type: string
+                  signingKeyRefs:
+                    description: Reference by name to Kubernetes secrets and corresponding signing algorithms. The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                    items:
+                      properties:
+                        algorithm:
+                          description: Algorithm to sign the wristband token using the signing key provided
+                          enum:
+                          - ES256
+                          - ES384
+                          - ES512
+                          - RS256
+                          - RS384
+                          - RS512
+                          type: string
+                        name:
+                          description: Name of the signing key. The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                          type: string
+                      required:
+                      - algorithm
+                      - name
+                      type: object
+                    type: array
+                  tokenDuration:
+                    description: Time span of the wristband token, in seconds.
+                    format: int64
+                    type: integer
+                required:
+                - issuer
+                - signingKeyRefs
+                type: object
             required:
             - hosts
             type: object
           status:
             description: ServiceStatus defines the observed state of Service
             properties:
+              festivalWristbandEnabled:
+                type: boolean
+              numAuthorizationPolicies:
+                format: int64
+                type: integer
+              numIdentityPolicies:
+                format: int64
+                type: integer
+              numMetadataPolicies:
+                format: int64
+                type: integer
               ready:
                 type: boolean
             required:
+            - festivalWristbandEnabled
+            - numAuthorizationPolicies
+            - numIdentityPolicies
+            - numMetadataPolicies
             - ready
             type: object
         type: object
@@ -399,6 +448,112 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: authorino-manager-role
+rules:
+- apiGroups:
+  - config.authorino.3scale.net
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.authorino.3scale.net
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-service-editor-role
+rules:
+- apiGroups:
+  - config.authorino.3scale.net
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - config.authorino.3scale.net
+  resources:
+  - services/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-service-viewer-role
+rules:
+- apiGroups:
+  - config.authorino.3scale.net
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.authorino.3scale.net
+  resources:
+  - services/status
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -437,75 +592,6 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  labels:
-    app: authorino
-  name: authorino-manager-role
-rules:
-- apiGroups:
-  - config.authorino.3scale.net
-  resources:
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - config.authorino.3scale.net
-  resources:
-  - services/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app: authorino
-  name: authorino-metrics-reader
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app: authorino
-  name: authorino-proxy-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
@@ -522,11 +608,10 @@ subjects:
   namespace: kuadrant-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  labels:
-    app: authorino
-  name: authorino-manager-rolebinding
+  name: manager-rolebinding
+  namespace: kuadrant-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -537,11 +622,10 @@ subjects:
   namespace: kuadrant-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  labels:
-    app: authorino
-  name: authorino-proxy-rolebinding
+  name: proxy-rolebinding
+  namespace: kuadrant-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -560,7 +644,7 @@ metadata:
   namespace: kuadrant-system
 spec:
   ports:
-  - name: http2
+  - name: grpc
     port: 50051
     protocol: TCP
   selector:
@@ -580,6 +664,22 @@ spec:
   - name: https
     port: 8443
     targetPort: https
+  selector:
+    app: authorino
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: authorino
+  name: authorino-oidc
+  namespace: kuadrant-system
+spec:
+  ports:
+  - name: https
+    port: 8083
+    protocol: TCP
   selector:
     app: authorino
     control-plane: controller-manager
@@ -606,6 +706,34 @@ spec:
     spec:
       containers:
       - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        command:
+        - /manager
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/3scale/authorino:latest
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 80Mi
+        volumeMounts:
+        - mountPath: /etc/ssl/certs/tls.crt
+          name: oidc-cert
+          readOnly: true
+          subPath: tls.crt
+        - mountPath: /etc/ssl/private/tls.key
+          name: oidc-cert
+          readOnly: true
+          subPath: tls.key
+      - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
@@ -615,21 +743,61 @@ spec:
         ports:
         - containerPort: 8443
           name: https
-      - args:
-        - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
-        command:
-        - /manager
-        image: quay.io/3scale/authorino:latest
-        env:
-          - name: AUTHORINO_SECRET_LABEL_KEY
-            value: "secret.kuadrant.io/managed-by"
-        name: manager
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
       terminationGracePeriodSeconds: 10
+      volumes:
+      - name: oidc-cert
+        secret:
+          defaultMode: 420
+          secretName: authorino-oidc-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: authorino
+  name: authorino-ca-cert
+  namespace: kuadrant-system
+spec:
+  commonName: '*.kuadrant-system.svc'
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: authorino-selfsigned-issuer
+  secretName: authorino-ca-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: authorino
+  name: authorino-oidc-server-cert
+  namespace: kuadrant-system
+spec:
+  dnsNames:
+  - authorino-oidc.kuadrant-system.svc
+  - authorino-oidc.kuadrant-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: authorino-ca-issuer
+  secretName: authorino-oidc-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: authorino
+  name: authorino-ca-issuer
+  namespace: kuadrant-system
+spec:
+  ca:
+    secretName: authorino-ca-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: authorino
+  name: authorino-selfsigned-issuer
+  namespace: kuadrant-system
+spec:
+  selfSigned: {}


### PR DESCRIPTION
When using the latest authorino version, cert-manager is needed to
deploy authorino, so:

- Updated authorino manifests to use the latest secret endpoints, etc..
- Updated makefile to isntall cert-manager

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>