### PR TITLE
Authorino: Use v0.1.0-pre version

### DIFF
--- a/authorinomanifests/authorino.yaml
+++ b/authorinomanifests/authorino.yaml
@@ -620,7 +620,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: quay.io/3scale/authorino:latest
+        image: quay.io/3scale/authorino:v0.1.0-pre
         env:
           - name: AUTHORINO_SECRET_LABEL_KEY
             value: "secret.kuadrant.io/managed-by"


### PR DESCRIPTION
To avoid using the cert-manager extension and have conflicts. Authorino
will fix this on https://github.com/Kuadrant/authorino/issues/128

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>