### PR TITLE
Store GVK for log before resource create

### DIFF
--- a/pkg/utils/k8s_utils.go
+++ b/pkg/utils/k8s_utils.go
@@ -79,13 +79,14 @@ func CreateOnlyK8SObject(k8sClient client.Client, obj runtime.Object) error {
 	if !ok {
 		return errors.New("runtime.Object could not be casted to client.Object")
 	}
+	k8sObjKind := k8sObj.DeepCopyObject().GetObjectKind()
 
 	err := k8sClient.Create(context.Background(), k8sObj)
-	logf.Log.Info("create resource", "GKV", k8sObj.GetObjectKind().GroupVersionKind(), "name", k8sObj.GetName(), "error", err)
+	logf.Log.Info("create resource", "GKV", k8sObjKind.GroupVersionKind(), "name", k8sObj.GetName(), "error", err)
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			// Omit error
-			logf.Log.Info("Already exists", "GKV", k8sObj.GetObjectKind().GroupVersionKind(), "name", k8sObj.GetName())
+			logf.Log.Info("Already exists", "GKV", k8sObjKind.GroupVersionKind(), "name", k8sObj.GetName())
 		} else {
 			return err
 		}


### PR DESCRIPTION
k8s client could remove `TypeMeta` after object create
We need to store `GVK` before operation to correct log display
Now install log prints with all GVK info
```
[dvolodin@localhost bin]$ ./kuadrantctl install
[dvolodin@localhost bin]$ ./kuadrantctl install
2021-07-23T13:01:18.062+0300	INFO	create resource	{"GKV": "/v1, Kind=Namespace", "name": "kuadrant-system", "error": null}
2021-07-23T13:01:20.069+0300	INFO	Resource file	{"name": "autogenerated/Base/Base.yaml"}
2021-07-23T13:01:20.096+0300	INFO	create resource	{"GKV": "rbac.authorization.k8s.io/v1, Kind=ClusterRole", "name": "istiod-kuadrant-system", "error": "clusterroles.rbac.authorization.k8s.io \"istiod-kuadrant-system\" already exists"}
2021-07-23T13:01:20.096+0300	INFO	Already exists	{"GKV": "rbac.authorization.k8s.io/v1, Kind=ClusterRole", "name": "istiod-kuadrant-system"}
2021-07-23T13:01:20.105+0300	INFO	create resource	{"GKV": "rbac.authorization.k8s.io/v1, Kind=ClusterRole", "name": "istio-reader-kuadrant-system", "error": "clusterroles.rbac.authorization.k8s.io \"istio-reader-kuadrant-system\" already exists"}
2021-07-23T13:01:20.105+0300	INFO	Already exists	{"GKV": "rbac.authorization.k8s.io/v1, Kind=ClusterRole", "name": "istio-reader-kuadrant-system"}
2021-07-23T13:01:20.114+0300	INFO	create resource	{"GKV": "rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding", "name": "istio-reader-kuadrant-system", "error": "clusterrolebindings.rbac.authorization.k8s.io \"istio-reader-kuadrant-system\" already exists"}
2021-07-23T13:01:20.114+0300	INFO	Already exists	{"GKV": "rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding", "name": "istio-reader-kuadrant-system"}
2021-07-23T13:01:20.120+0300	INFO	create resource	{"GKV": "rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding", "name": "istiod-kuadrant-system", "error": "clusterrolebindings.rbac.authorization.k8s.io \"istiod-kuadrant-system\" already exists"}
2021-07-23T13:01:20.120+0300	INFO	Already exists	{"GKV": "rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding", "name": "istiod-kuadrant-system"}
2021-07-23T13:01:20.128+0300	INFO	create resource	{"GKV": "rbac.authorization.k8s.io/v1, Kind=Role", "name": "istiod-kuadrant-system", "error": null}
2021-07-23T13:01:20.136+0300	INFO	create resource	{"GKV": "rbac.authorization.k8s.io/v1, Kind=RoleBinding", "name": "istiod-kuadrant-system", "error": null}
2021-07-23T13:01:20.143+0300	INFO	create resource	{"GKV": "/v1, Kind=ServiceAccount", "name": "istio-reader-service-account", "error": null}
2021-07-23T13:01:20.158+0300	INFO	create resource	{"GKV": "/v1, Kind=ServiceAccount", "name": "istiod-service-account", "error": null}
```