### PR TITLE
Update Kind to v0.11.1 and bind to the specific k8s version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: Makefile
 KIND = $(PROJECT_PATH)/bin/kind
 KIND_CLUSTER_NAME = kuadrant-local
 $(KIND):
-	$(call go-get-tool,$(KIND),sigs.k8s.io/kind@v0.10.0)
+	$(call go-get-tool,$(KIND),sigs.k8s.io/kind@v0.11.1)
 
 .PHONY : kind
 kind: $(KIND)

--- a/utils/kind/cluster.yaml
+++ b/utils/kind/cluster.yaml
@@ -3,6 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   # port forward 80 on the host to 80 on this node
+  image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
   extraPortMappings:
   - containerPort: 30950
     hostPort: 9080


### PR DESCRIPTION
Kind v0.11.1 is much stable than 0.10.0 and could run k8s grater than 1.20
In this case it's better to bind specific k8s version the kind config to control version and avoid changing it

P.S. I can't get working kind v0.10.0 and k8s 1.20.2 on my Fedora 34. Sorry :cry:  