### PR TITLE
generate kuadrant authconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ go install github.com/kuadrant/kuadrantctl@latest
 * [Apply Kuadrant API objects](doc/api-apply.md)
 * [Generate Istio virtualservice objects](doc/generate-istio-virtualservice.md)
 * [Generate Istio authenticationpolicy objects](doc/generate-istio-authorizationpolicy.md)
+* [Generate kuadrat authconfig objects](doc/generate-kuadrant-authconfig.md)
 
 ## Contributing
 The [Development guide](doc/development.md) describes how to build the kuadrantctl CLI and how to test your changes before submitting a patch or opening a PR.

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -12,6 +12,7 @@ func generateCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(generateIstioCommand())
+	cmd.AddCommand(generateKuadrantCommand())
 
 	return cmd
 }

--- a/cmd/generate_kuadrant.go
+++ b/cmd/generate_kuadrant.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func generateKuadrantCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kuadrant",
+		Short: "Generate Kuadrant resources",
+		Long:  "Generate Kuadrant resorces",
+	}
+
+	cmd.AddCommand(generateKuadrantAuthconfigCommand())
+
+	return cmd
+}

--- a/cmd/generate_kuadrant.go
+++ b/cmd/generate_kuadrant.go
@@ -8,7 +8,7 @@ func generateKuadrantCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kuadrant",
 		Short: "Generate Kuadrant resources",
-		Long:  "Generate Kuadrant resorces",
+		Long:  "Generate Kuadrant resources",
 	}
 
 	cmd.AddCommand(generateKuadrantAuthconfigCommand())

--- a/cmd/generate_kuadrant_authconfig.go
+++ b/cmd/generate_kuadrant_authconfig.go
@@ -103,6 +103,10 @@ func generateKuadrantAuthConfig(cmd *cobra.Command, doc *openapi3.T) (*authorino
 	}
 
 	authConfig := &authorinov1beta1.AuthConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AuthConfig",
+			APIVersion: "authorino.kuadrant.io/v1beta1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: objectName,
 		},

--- a/cmd/generate_kuadrant_authconfig.go
+++ b/cmd/generate_kuadrant_authconfig.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	authorinov1beta1 "github.com/kuadrant/authorino/api/v1beta1"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	authorinoutils "github.com/kuadrant/kuadrantctl/pkg/authorino"
+	"github.com/kuadrant/kuadrantctl/pkg/utils"
+)
+
+var (
+	generateKuadrantAuthConfigOAS        string
+	generateKuadrantAuthConfigPublicHost string
+)
+
+func generateKuadrantAuthconfigCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "authconfig",
+		Short: "Generate kuadrant authconfig from OpenAPI 3.x",
+		Long:  "Generate kuadrant authconfig from OpenAPI 3.x",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGenerateKuadrantAuthconfigCommand(cmd, args)
+		},
+	}
+
+	// OpenAPI ref
+	cmd.Flags().StringVar(&generateKuadrantAuthConfigOAS, "oas", "", "/path/to/file.[json|yaml|yml] OR http[s]://domain/resource/path.[json|yaml|yml] OR - (required)")
+	err := cmd.MarkFlagRequired("oas")
+	if err != nil {
+		panic(err)
+	}
+
+	// public host
+	cmd.Flags().StringVar(&generateKuadrantAuthConfigPublicHost, "public-host", "", "The address used by a client when attempting to connect to a service (required)")
+	err = cmd.MarkFlagRequired("public-host")
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func runGenerateKuadrantAuthconfigCommand(cmd *cobra.Command, args []string) error {
+	dataRaw, err := utils.ReadExternalResource(generateKuadrantAuthConfigOAS)
+	if err != nil {
+		return err
+	}
+
+	openapiLoader := openapi3.NewLoader()
+	doc, err := openapiLoader.LoadFromData(dataRaw)
+	if err != nil {
+		return err
+	}
+
+	err = doc.Validate(openapiLoader.Context)
+	if err != nil {
+		return fmt.Errorf("OpenAPI validation error: %w", err)
+	}
+
+	authConfig, err := generateKuadrantAuthConfig(cmd, doc)
+	if err != nil {
+		return err
+	}
+
+	jsonData, err := json.Marshal(authConfig)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
+	return nil
+}
+
+func generateKuadrantAuthConfig(cmd *cobra.Command, doc *openapi3.T) (*authorinov1beta1.AuthConfig, error) {
+	objectName, err := utils.K8sNameFromOpenAPITitle(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	identityList, err := authorinoutils.AuthConfigIdentitiesFromOpenAPI(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	metadataList, err := generateKuadrantAuthConfigMetadata(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	authorizationList, err := generateKuadrantAuthConfigAuthorization(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	responseList, err := generateKuadrantAuthConfigResponse(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	authConfig := &authorinov1beta1.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: objectName,
+		},
+		Spec: authorinov1beta1.AuthConfigSpec{
+			Hosts:         []string{generateKuadrantAuthConfigPublicHost},
+			Identity:      identityList,
+			Metadata:      metadataList,
+			Authorization: authorizationList,
+			Response:      responseList,
+			Patterns:      nil,
+			Conditions:    nil,
+		},
+	}
+	return authConfig, nil
+}
+
+func generateKuadrantAuthConfigMetadata(doc *openapi3.T) ([]*authorinov1beta1.Metadata, error) {
+	return nil, nil
+}
+
+func generateKuadrantAuthConfigAuthorization(doc *openapi3.T) ([]*authorinov1beta1.Authorization, error) {
+	return nil, nil
+}
+
+func generateKuadrantAuthConfigResponse(doc *openapi3.T) ([]*authorinov1beta1.Response, error) {
+	return nil, nil
+}

--- a/doc/generate-kuadrant-authconfig.md
+++ b/doc/generate-kuadrant-authconfig.md
@@ -1,0 +1,29 @@
+## Generate Kuadrant AuthConfig objects
+
+The `kuadrantctl generate kuadrant authconfig` command generates an [Authorino AuthConfig](https://github.com/Kuadrant/authorino/blob/v0.7.0/docs/architecture.md#the-authorino-authconfig-custom-resource-definition-crd)
+from your [OpenAPI Specification (OAS) 3.x](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md) and kubernetes service information.
+
+### OpenAPI specification
+
+OpenAPI document resource can be provided by one of the following channels:
+* Filename in the available path.
+* URL format (supported schemes are HTTP and HTTPS). The CLI will try to download from the given address.
+* Read from stdin standard input stream.
+
+### Usage :
+
+```shell
+$ kuadrantctl generate kuadrant authconfig -h
+Generate kuadrant authconfig from OpenAPI 3.x
+
+Usage:
+  kuadrantctl generate kuadrant authconfig [flags]
+
+Flags:
+  -h, --help                 help for authconfig
+      --oas string           /path/to/file.[json|yaml|yml] OR http[s]://domain/resource/path.[json|yaml|yml] OR - (required)
+      --public-host string   The address used by a client when attempting to connect to a service (required)
+
+Global Flags:
+  -v, --verbose   verbose output
+```

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/getkin/kin-openapi v0.76.0
 	github.com/google/uuid v1.3.0
+	github.com/kuadrant/authorino v0.7.0
 	github.com/kuadrant/authorino-operator v0.1.0
 	github.com/kuadrant/kuadrant-controller v0.2.1
 	github.com/kuadrant/limitador-operator v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -456,6 +456,7 @@ github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kuadrant/authorino v0.7.0 h1:YgeFzteyzlfFZqWZN3b7cXbyOZZ2vgHP2UHp7yktrvg=
 github.com/kuadrant/authorino v0.7.0/go.mod h1:+ddl2McmSC8vKufmR/iA4ILOwkTCe5dbX+uzWSZ4w1Q=
 github.com/kuadrant/authorino-operator v0.1.0 h1:2MluwjhdtQl/z3C5BkM7BMvQr8WRzlUrDRe96DYdq6w=
 github.com/kuadrant/authorino-operator v0.1.0/go.mod h1:enEBTG0San0QUHhqZ08OXiVDkURkRE2UBEQelcNTiGI=

--- a/pkg/authorino/auth_config.go
+++ b/pkg/authorino/auth_config.go
@@ -75,7 +75,7 @@ func AuthConfigConditionsFromOperation(opPath, opVerb string) []authorinov1beta1
 	return []authorinov1beta1.JSONPattern{
 		{
 			JSONPatternExpression: authorinov1beta1.JSONPatternExpression{
-				Selector: `context.request.http.path@extract{"sep":"/"}`,
+				Selector: `context.request.http.path.@extract:{"sep":"/"}`,
 				Operator: "eq",
 				Value:    opPath,
 			},

--- a/pkg/authorino/auth_config.go
+++ b/pkg/authorino/auth_config.go
@@ -70,7 +70,7 @@ func AuthConfigConditionsFromOperation(opPath, opVerb string) []authorinov1beta1
 	return []authorinov1beta1.JSONPattern{
 		{
 			JSONPatternExpression: authorinov1beta1.JSONPatternExpression{
-				Selector: "context.request.http.path",
+				Selector: `context.request.http.path@extract{"sep":"/"}`,
 				Operator: "eq",
 				Value:    opPath,
 			},

--- a/pkg/authorino/auth_config.go
+++ b/pkg/authorino/auth_config.go
@@ -82,9 +82,9 @@ func AuthConfigConditionsFromOperation(opPath, opVerb string) []authorinov1beta1
 		},
 		{
 			JSONPatternExpression: authorinov1beta1.JSONPatternExpression{
-				Selector: "context.request.http.method",
+				Selector: "context.request.http.method.@case:lower",
 				Operator: "eq",
-				Value:    opVerb,
+				Value:    strings.ToLower(opVerb),
 			},
 		},
 	}

--- a/pkg/authorino/auth_config.go
+++ b/pkg/authorino/auth_config.go
@@ -2,6 +2,7 @@ package authorino
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	authorinov1beta1 "github.com/kuadrant/authorino/api/v1beta1"

--- a/pkg/authorino/auth_config.go
+++ b/pkg/authorino/auth_config.go
@@ -1,0 +1,128 @@
+package authorino
+
+import (
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	authorinov1beta1 "github.com/kuadrant/authorino/api/v1beta1"
+
+	"github.com/kuadrant/kuadrantctl/pkg/utils"
+)
+
+func AuthConfigIdentitiesFromOpenAPI(oasDoc *openapi3.T) ([]*authorinov1beta1.Identity, error) {
+	identities := []*authorinov1beta1.Identity{}
+
+	for path, pathItem := range oasDoc.Paths {
+		for opVerb, operation := range pathItem.Operations() {
+			secReqsP := utils.OpenAPIOperationSecRequirements(oasDoc, operation)
+
+			if secReqsP == nil {
+				continue
+			}
+
+			for _, secReq := range *secReqsP {
+				// Authorino AuthConfig currently only supports one identity method for each identity evaluator.
+				// It does not support, for instance, auth based on two api keys or api key AND oidc.
+				// Thus, some OpenAPI 3.X security requirements are not supported:
+				//
+				// Not Supported:
+				// security:
+				//   - petstore_api_key: []
+				//     toystore_api_key: []
+				//     toystore_oidc: []
+				//
+				// Supported:
+				// security:
+				//   - petstore_api_key: []
+				//   - toystore_api_key: []
+				//   - toystore_oidc: []
+				//
+
+				// scopes not being used now
+				for secSchemeName := range secReq {
+
+					secSchemeI, err := oasDoc.Components.SecuritySchemes.JSONLookup(secSchemeName)
+					if err != nil {
+						return nil, err
+					}
+
+					secScheme := secSchemeI.(*openapi3.SecurityScheme) // panic if assertion fails
+
+					identity, err := AuthConfigIdentityFromSecurityRequirement(
+						operation.OperationID, // TODO(eastizle): OperationID can be null, fallback to some custom name
+						path, opVerb, secScheme)
+					if err != nil {
+						return nil, err
+					}
+
+					identities = append(identities, identity)
+					// currently only support for one schema per requirement
+					break
+				}
+			}
+
+		}
+	}
+	return identities, nil
+}
+
+func AuthConfigConditionsFromOperation(opPath, opVerb string) []authorinov1beta1.JSONPattern {
+	return []authorinov1beta1.JSONPattern{
+		{
+			JSONPatternExpression: authorinov1beta1.JSONPatternExpression{
+				Selector: "context.request.http.path",
+				Operator: "eq",
+				Value:    opPath,
+			},
+		},
+		{
+			JSONPatternExpression: authorinov1beta1.JSONPatternExpression{
+				Selector: "context.request.http.method",
+				Operator: "eq",
+				Value:    opVerb,
+			},
+		},
+	}
+}
+
+func AuthConfigIdentityFromSecurityRequirement(name, opPath, opVerb string, secScheme *openapi3.SecurityScheme) (*authorinov1beta1.Identity, error) {
+	if secScheme == nil {
+		return nil, fmt.Errorf("sec scheme nil for operation path:%s method:%s", opPath, opVerb)
+	}
+
+	identity := &authorinov1beta1.Identity{
+		// TODO(eastizle): OperationID can be null, fallback to some custom name
+		Name:       name,
+		Conditions: AuthConfigConditionsFromOperation(opPath, opVerb),
+	}
+
+	switch secScheme.Type {
+	case "apiKey":
+		AuthConfigIdentityFromApiKeyScheme(identity, secScheme)
+	case "openIdConnect":
+		AuthConfigIdentityFromOIDCScheme(identity, secScheme)
+	default:
+		return nil, fmt.Errorf("sec scheme type %s not supported for path:%s method:%s", secScheme.Type, opPath, opVerb)
+	}
+
+	return identity, nil
+}
+
+func AuthConfigIdentityFromApiKeyScheme(identity *authorinov1beta1.Identity, secScheme *openapi3.SecurityScheme) {
+	// Fixed label selector for now
+	apikey := authorinov1beta1.Identity_APIKey{
+		LabelSelectors: map[string]string{
+			"authorino.kuadrant.io/managed-by": "authorino",
+		},
+	}
+
+	identity.Credentials.In = authorinov1beta1.Credentials_In(secScheme.In)
+	identity.Credentials.KeySelector = secScheme.Name
+	identity.APIKey = &apikey
+}
+
+func AuthConfigIdentityFromOIDCScheme(identity *authorinov1beta1.Identity, secScheme *openapi3.SecurityScheme) {
+	identity.Oidc = &authorinov1beta1.Identity_OidcConfig{
+		Endpoint: secScheme.OpenIdConnectUrl,
+	}
+}


### PR DESCRIPTION
New command to generate [AuthConfig](https://github.com/Kuadrant/authorino/blob/v0.7.0/docs/architecture.md#the-authorino-authconfig-custom-resource-definition-crd) objects from your OpenAPI spec.

```shell
kuadrantctl generate kuadrant authconfig
```

Running example:

Using the following OpenAPI spec that contains three operations:
* one not secured
* one with apiKey sec requirement 
* one with OIDC sec requirement 
```yaml
---
openapi: "3.1.0"
info:
  title: "Pet Store API"
  version: "1.0.0"
servers:
  - url: https://toplevel.example.io/v1
paths:
  /cat:
    get:  # No sec requirements
      operationId: "getCat"
      responses:
        405:
          description: "invalid input"
    post:  # API key
      operationId: "postCat"
      security:
        - petstore_api_key: []
      responses:
        405:
          description: "invalid input"
  /dog:
    get:  # OIDC
      operationId: "getDog"
      security:
        - petstore_oidc:
          - read:dogs
      responses:
        405:
          description: "invalid input"
components:
  securitySchemes:
    petstore_api_key:
      type: apiKey
      name: api_key
      in: header
    petstore_oidc:
      type: openIdConnect
      openIdConnectUrl: http://example.org/auth/realms/myrealm
```

The generated AuthConfig would be:

```yaml
kind: AuthConfig
apiVersion: authorino.kuadrant.io/v1beta1
metadata:
  name: petstoreapi
  creationTimestamp: null
spec:
  hosts:
    - example.io
  identity:
    - name: postCat
      when:
        - selector: context.request.http.path.@extract:{"sep":"/"}
          operator: eq
          value: /cat
        - selector: context.request.http.method.@case:lower
          operator: eq
          value: post
      credentials:
        in: header
        keySelector: api_key
      apiKey:
        labelSelectors:
          app: petstoreapi
          authorino.kuadrant.io/managed-by: authorino
    - name: getDog
      when:
        - selector: context.request.http.path.@extract:{"sep":"/"}
          operator: eq
          value: /dog
        - selector: context.request.http.method.@case:lower
          operator: eq
          value: get
      credentials:
        keySelector: ""
      oidc:
        endpoint: http://example.org/auth/realms/myrealm
status:
  ready: false
  numIdentitySources: 0
  numMetadataSources: 0
  numAuthorizationPolicies: 0
  numResponseItems: 0
  festivalWristbandEnabled: false
```