### PR TITLE
generate virtualservice: path match type flag

### DIFF
--- a/cmd/generate_istio_virtualservice.go
+++ b/cmd/generate_istio_virtualservice.go
@@ -21,6 +21,7 @@ var (
 	generateIstioVSServiceNamespace string
 	generateIstioVSServicePort      int32
 	generateIstioVSGateways         []string
+	generateIstioVSPrefixMatch      bool
 )
 
 func generateIstioVirtualServiceCommand() *cobra.Command {
@@ -71,6 +72,9 @@ func generateIstioVirtualServiceCommand() *cobra.Command {
 		panic(err)
 	}
 
+	// exact match
+	cmd.Flags().BoolVar(&generateIstioVSPrefixMatch, "path-prefix-match", false, "Path match type (defaults to exact match type)")
+
 	return cmd
 }
 
@@ -116,7 +120,7 @@ func generateIstioVirtualService(cmd *cobra.Command, doc *openapi3.T) (*istionet
 		Port: &istionetworkingapi.PortSelector{Number: uint32(generateIstioVSServicePort)},
 	}
 
-	httpRoutes, err := istioutils.HTTPRoutesFromOpenAPI(doc, destination)
+	httpRoutes, err := istioutils.HTTPRoutesFromOpenAPI(doc, destination, generateIstioVSPrefixMatch)
 	if err != nil {
 		return nil, err
 	}

--- a/doc/generate-istio-virtualservice.md
+++ b/doc/generate-istio-virtualservice.md
@@ -23,6 +23,7 @@ Flags:
       --gateway strings            Gateways (required)
   -h, --help                       help for virtualservice
       --oas string                 /path/to/file.[json|yaml|yml] OR http[s]://domain/resource/path.[json|yaml|yml] OR - (required)
+      --path-prefix-match          Path match type (defaults to exact match type)
       --public-host string         The address used by a client when attempting to connect to a service (required)
       --service-name string        Service name (required)
       --service-namespace string   Service namespace (required)

--- a/pkg/istio/http_route.go
+++ b/pkg/istio/http_route.go
@@ -5,20 +5,30 @@ import (
 	istioapi "istio.io/api/networking/v1beta1"
 )
 
-func HTTPRoutesFromOpenAPI(oasDoc *openapi3.T, destination *istioapi.Destination) ([]*istioapi.HTTPRoute, error) {
+func HTTPRoutesFromOpenAPI(oasDoc *openapi3.T, destination *istioapi.Destination, pathMatchPrefix bool) ([]*istioapi.HTTPRoute, error) {
 	httpRoutes := []*istioapi.HTTPRoute{}
 
 	// Path based routing
 	for path, pathItem := range oasDoc.Paths {
+
+		var pathMatchType *istioapi.StringMatch
+		if pathMatchPrefix {
+			pathMatchType = &istioapi.StringMatch{
+				MatchType: &istioapi.StringMatch_Prefix{Prefix: path},
+			}
+		} else {
+			pathMatchType = &istioapi.StringMatch{
+				MatchType: &istioapi.StringMatch_Exact{Exact: path},
+			}
+		}
+
 		for opVerb, operation := range pathItem.Operations() {
 			httpRoute := &istioapi.HTTPRoute{
 				// TODO(eastizle): OperationID can be null, fallback to some custom name
 				Name: operation.OperationID,
 				Match: []*istioapi.HTTPMatchRequest{
 					{
-						Uri: &istioapi.StringMatch{
-							MatchType: &istioapi.StringMatch_Exact{Exact: path},
-						},
+						Uri: pathMatchType,
 						Method: &istioapi.StringMatch{
 							MatchType: &istioapi.StringMatch_Exact{Exact: opVerb},
 						},


### PR DESCRIPTION
By default, the command `kuadrantctl generate istio virtualservice` generates Istio VirtualService object with path match type `exact`. 

```yaml
http:
    - name: getCat
      match:
        - uri:
            exact: /cat
          method:
            exact: GET
```


OAS 3.X does not explicitly specify it, so this PR adds a command flag to support a new path match type: `prefix`. With the  command line option `--path-prefix-match`
```
kuadrantctl generate istio virtualservice --path-prefix-match
```

The VirtualService will be generated for path match type prefix.

```yaml
http:
    - name: getDog
      match:
        - uri:
            prefix: /dog
          method:
            exact: GET

```

This behavior modifies all the operations read from the OAS. If the path match type needs to be specified per OAS operaton, it is best to explore OAS extensions. 
