### PR TITLE
OAS server path as base path for matchers

### DIFF
--- a/examples/oas3/petstore-with-kuadrant-extensions.yaml
+++ b/examples/oas3/petstore-with-kuadrant-extensions.yaml
@@ -13,7 +13,7 @@ info:
         - name: istio-ingressgateway
           namespace: istio-system
 servers:
-  - url: https://example.io/v1
+  - url: https://example.io/api/v1
 paths:
   /cat:
     x-kuadrant:  ## Path level Kuadrant Extension

--- a/pkg/gatewayapi/http_route.go
+++ b/pkg/gatewayapi/http_route.go
@@ -77,6 +77,11 @@ func HTTPRouteRulesFromOAS(doc *openapi3.T) []gatewayapiv1beta1.HTTPRouteRule {
 	// TODO(eguzki): consider about grouping operations as HTTPRouteMatch objects in fewer HTTPRouteRule objects
 	rules := make([]gatewayapiv1beta1.HTTPRouteRule, 0)
 
+	basePath, err := utils.BasePathFromOpenAPI(doc)
+	if err != nil {
+		panic(err)
+	}
+
 	// Paths
 	for path, pathItem := range doc.Paths {
 		kuadrantPathExtension, err := utils.NewKuadrantOASPathExtension(pathItem)
@@ -104,7 +109,7 @@ func HTTPRouteRulesFromOAS(doc *openapi3.T) []gatewayapiv1beta1.HTTPRouteRule {
 				backendRefs = kuadrantOperationExtension.BackendRefs
 			}
 
-			rules = append(rules, buildHTTPRouteRule(path, pathItem, verb, operation, backendRefs))
+			rules = append(rules, buildHTTPRouteRule(basePath, path, pathItem, verb, operation, backendRefs))
 		}
 	}
 
@@ -137,8 +142,8 @@ func ExtractLabelsFromOAS(doc *openapi3.T) (map[string]string, bool) {
 	return nil, false
 }
 
-func buildHTTPRouteRule(path string, pathItem *openapi3.PathItem, verb string, op *openapi3.Operation, backendRefs []gatewayapiv1beta1.HTTPBackendRef) gatewayapiv1beta1.HTTPRouteRule {
-	match := utils.OpenAPIMatcherFromOASOperations(path, pathItem, verb, op)
+func buildHTTPRouteRule(basePath, path string, pathItem *openapi3.PathItem, verb string, op *openapi3.Operation, backendRefs []gatewayapiv1beta1.HTTPBackendRef) gatewayapiv1beta1.HTTPRouteRule {
+	match := utils.OpenAPIMatcherFromOASOperations(basePath, path, pathItem, verb, op)
 
 	return gatewayapiv1beta1.HTTPRouteRule{
 		BackendRefs: backendRefs,


### PR DESCRIPTION
# What

OAS server path as base path for matchers

> **Note1**: Limitation: only read the first item when there are multiple servers

> **Note2**: Limitation: `servers` element in path item or operation items are not implemented.

When OpenAPI doc specifies base path in the `servers` **top level object**, all the operations are prefixed with the base path of the server object. For example:

```yaml
servers:
  - url: https://example.io/api/v1
    description: Release v1
  - url: https://example.io/api/v2
    description: Release v2
```
For this example, all the paths will be prefixed with `/api/v1` base path. The second server object is omitted. 

# Verification Steps

* Clone the repo and checkout to the PR branch `httproute-kuadrant-extensions`
```bash
git clone https://github.com/Kuadrant/kuadrantctl.git
cd kuadrantctl
git checkout kuadrant-extensions-server-path
```
* Setup cluster, istio and Gateway API CRDs
```bash
make local-setup
```
* Build and install CLI in `bin/kuadrantctl` path
```bash
make install
```
* Install Kuadrant service protection. The CLI can be used to install kuadrant v0.4.1
```bash
bin/kuadrantctl install
```
* Deploy petstore backend API
```bash
kubectl create namespace petstore
kubectl apply -n petstore -f examples/petstore/petstore.yaml
```
* Let's create Petstore's OpenAPI spec

<details>

```yaml
cat <<EOF >petstore-openapi.yaml
---
openapi: "3.0.3"
info:
  title: "Pet Store API"
  version: "1.0.0"
  x-kuadrant:
    route:
      name: "petstore"
      namespace: "petstore"
      hostnames:
        - example.com
      parentRefs:
        - name: istio-ingressgateway
          namespace: istio-system
servers:
  - url: https://example.io/api/v1
paths:
  /cat:
    x-kuadrant:  ## Path level Kuadrant Extension
      enable: true
      backendRefs:
        - name: petstore
          port: 80
          namespace: petstore
      rate_limit:
        rates:
          - limit: 1
            duration: 10
            unit: second
        counters:
          - request.headers.x-forwarded-for
    get:  # Added to the route and rate limited
      operationId: "getCat"
      responses:
        405:
          description: "invalid input"
    post:  # NOT added to the route
      x-kuadrant:  ## Operation level Kuadrant Extension
        enable: false
        backendRefs:
          - name: petstore
            port: 80
            namespace: petstore
        rate_limit:
          rates:
            - limit: 2
              duration: 10
              unit: second
          counters:
            - request.headers.x-forwarded-for
      operationId: "postCat"
      responses:
        405:
          description: "invalid input"
  /dog:
    get:  # Added to the route and rate limited
      x-kuadrant:  ## Operation level Kuadrant Extension
        enable: true
        backendRefs:
          - name: petstore
            port: 80
            namespace: petstore
        rate_limit:
          rates:
            - limit: 3
              duration: 10
              unit: second
          counters:
            - request.headers.x-forwarded-for
      operationId: "getDog"
      responses:
        405:
          description: "invalid input"
    post:  # Added to the route and NOT rate limited
      x-kuadrant:  ## Operation level Kuadrant Extension
        enable: true
        backendRefs:
          - name: petstore
            port: 80
            namespace: petstore
      operationId: "postDog"
      responses:
        405:
          description: "invalid input"
  /mouse:
    get:  # NOT added to the route
      operationId: "getMouse"
      responses:
        405:
          description: "invalid input"
EOF
```

</details>

| Operation | Match | Applied config |
| --- | --- | --- |
| `GET /cat` | `GET /api/v1/cat` | It should return 200 Ok and be rate limited (1 req / 10 seconds)  |
| `POST /cat` | `POST /api/v1/cat` | Not added to the HTTPRoute. It should return 404 Not Found  |
| `GET /dog` | `GET /api/v1/dog`  | It should return 200 Ok and be rate limited (3 req / 10 seconds) |
| `POST /dog`  | `POST /api/v1/dog` | It should return 200 Ok and NOT rate limited  |
| `GET /mouse` | `GET /api/v1/mouse`  | Not added to the HTTPRoute. It should return 404 Not Found  |


* Create the HTTPRoute using the CLI
```bash
bin/kuadrantctl generate gatewayapi httproute --oas petstore-openapi.yaml | kubectl apply -n petstore -f -
```

* Create the Rate Limit Policy
```bash
bin/kuadrantctl generate kuadrant ratelimitpolicy --oas petstore-openapi.yaml | kubectl apply -n petstore -f -
```

* Test OpenAPI endpoints
  * `GET /api/v1/cat` -> It should return 200 Ok and be rate limited (1 req / 10 seconds)

```bash
curl --resolve example.com:9080:127.0.0.1 -v "http://example.com:9080/api/v1/cat"
```
  *   `POST /api/v1/cat` -> Not added to the HTTPRoute. It should return 404 Not Found
```bash
curl --resolve example.com:9080:127.0.0.1 -v -X POST "http://example.com:9080/api/v1/cat"
```
  * `GET /api/v1/dog` -> It should return 200 Ok and be rate limited (3 req / 10 seconds)

```bash  
curl --resolve example.com:9080:127.0.0.1 -v "http://example.com:9080/api/v1/dog"
```

   *  `POST /api/v1/dog` -> It should return 200 Ok and NOT rate limited

```bash  
curl --resolve example.com:9080:127.0.0.1 -v -X POST "http://example.com:9080/api/v1/dog"
```

  *  `GET /api/v1/mouse` -> Not added to the HTTPRoute. It should return 404 Not Found

```bash  
curl --resolve example.com:9080:127.0.0.1 -v -X POST "http://example.com:9080/api/v1/mouse"
```

* Clean environment
```bash  
make local-cleanup
```