### PR TITLE
Kuadrant extension enhancements

### DIFF
--- a/cmd/generate_gatewayapi_httproute.go
+++ b/cmd/generate_gatewayapi_httproute.go
@@ -65,7 +65,7 @@ func runGenerateGatewayApiHttpRoute(cmd *cobra.Command, args []string) error {
 }
 
 func buildHTTPRoute(doc *openapi3.T) *gatewayapiv1beta1.HTTPRoute {
-	httpRoute := &gatewayapiv1beta1.HTTPRoute{
+	return &gatewayapiv1beta1.HTTPRoute{
 		TypeMeta: v1.TypeMeta{
 			APIVersion: "gateway.networking.k8s.io/v1beta1",
 			Kind:       "HTTPRoute",
@@ -79,12 +79,4 @@ func buildHTTPRoute(doc *openapi3.T) *gatewayapiv1beta1.HTTPRoute {
 			Rules:     gatewayapi.HTTPRouteRulesFromOAS(doc),
 		},
 	}
-
-	// Extract and set labels
-	labels, ok := gatewayapi.ExtractLabelsFromOAS(doc)
-	if ok {
-		httpRoute.ObjectMeta.Labels = labels
-	}
-
-	return httpRoute
 }

--- a/doc/openapi-kuadrant-extensions.md
+++ b/doc/openapi-kuadrant-extensions.md
@@ -10,6 +10,8 @@ info:
     route:  ## HTTPRoute metadata
       name: "petstore"
       namespace: "petstore"
+      labels:  ## map[string]string
+        deployment: petstore
       hostnames:  ## []gateway.networking.k8s.io/v1beta1.Hostname
         - example.com
       parentRefs:  ## []gateway.networking.k8s.io/v1beta1.ParentReference
@@ -27,7 +29,8 @@ is the default when there is no operation level configuration.
 paths:
   /cat:
     x-kuadrant:  ## Path level Kuadrant Extension
-      enable: true  ## Add to the HTTPRoute. Optional. Default: false
+      disable: true  ## Remove from the HTTPRoute. Optional. Default: false
+      pathMatchType: Exact ## Specifies how to match against the path Value. Valid values: [Exact;PathPrefix]. Optional. Default: Exact
       backendRefs:  ## Backend references to be included in the HTTPRoute. []gateway.networking.k8s.io/v1beta1.HTTPBackendRef. Optional.
         - name: petstore
           port: 80
@@ -55,7 +58,8 @@ paths:
   /cat:
     get:
       x-kuadrant:  ## Path level Kuadrant Extension
-        enable: true  ## Add to the HTTPRoute. Optional. Default: false
+        disable: true  ## Remove from the HTTPRoute. Optional. Default: path level "disable" value
+        pathMatchType: Exact ## Specifies how to match against the path Value. Valid values: [Exact;PathPrefix]. Optional. Default: Exact
         backendRefs:  ## Backend references to be included in the HTTPRoute. Optional.
           - name: petstore
             port: 80

--- a/pkg/utils/kuadrant_oas_extension_types.go
+++ b/pkg/utils/kuadrant_oas_extension_types.go
@@ -14,6 +14,7 @@ type RouteObject struct {
 	Namespace  *string                             `json:"namespace,omitempty"`
 	Hostnames  []gatewayapiv1beta1.Hostname        `json:"hostnames,omitempty"`
 	ParentRefs []gatewayapiv1beta1.ParentReference `json:"parentRefs,omitempty"`
+	Labels     map[string]string                   `json:"labels,omitempty"`
 }
 
 type KuadrantOASInfoExtension struct {
@@ -48,14 +49,20 @@ type KuadrantRateLimitExtension struct {
 }
 
 type KuadrantOASPathExtension struct {
-	Enable      *bool                              `json:"enable,omitempty"`
-	BackendRefs []gatewayapiv1beta1.HTTPBackendRef `json:"backendRefs,omitempty"`
-	RateLimit   *KuadrantRateLimitExtension        `json:"rate_limit,omitempty"`
+	Disable       *bool                              `json:"disable,omitempty"`
+	PathMatchType *gatewayapiv1beta1.PathMatchType   `json:"pathMatchType,omitempty"`
+	BackendRefs   []gatewayapiv1beta1.HTTPBackendRef `json:"backendRefs,omitempty"`
+	RateLimit     *KuadrantRateLimitExtension        `json:"rate_limit,omitempty"`
 }
 
-func (k *KuadrantOASPathExtension) IsEnabled() bool {
+func (k *KuadrantOASPathExtension) IsDisabled() bool {
 	// Set default
-	return ptr.Deref(k.Enable, false)
+	return ptr.Deref(k.Disable, false)
+}
+
+func (k *KuadrantOASPathExtension) GetPathMatchType() gatewayapiv1beta1.PathMatchType {
+	// Set default
+	return ptr.Deref(k.PathMatchType, gatewayapiv1beta1.PathMatchExact)
 }
 
 func NewKuadrantOASPathExtension(pathItem *openapi3.PathItem) (*KuadrantOASPathExtension, error) {

--- a/pkg/utils/oas_utils.go
+++ b/pkg/utils/oas_utils.go
@@ -97,8 +97,7 @@ func BasePathFromOpenAPI(obj *openapi3.T) (string, error) {
 	return serverURL.Path, nil
 }
 
-func OpenAPIMatcherFromOASOperations(basePath, path string, pathItem *openapi3.PathItem, verb string, op *openapi3.Operation) gatewayapiv1beta1.HTTPRouteMatch {
-
+func OpenAPIMatcherFromOASOperations(basePath, path string, pathItem *openapi3.PathItem, verb string, op *openapi3.Operation, pathMatchType gatewayapiv1beta1.PathMatchType) gatewayapiv1beta1.HTTPRouteMatch {
 	// remove the last slash of the Base Path
 	sanitizedBasePath := LastSlashRegexp.ReplaceAllString(basePath, "")
 
@@ -126,8 +125,7 @@ func OpenAPIMatcherFromOASOperations(basePath, path string, pathItem *openapi3.P
 	return gatewayapiv1beta1.HTTPRouteMatch{
 		Method: &[]gatewayapiv1beta1.HTTPMethod{gatewayapiv1beta1.HTTPMethod(verb)}[0],
 		Path: &gatewayapiv1beta1.HTTPPathMatch{
-			// TODO(eguzki): consider other path match types like PathPrefix
-			Type:  &[]gatewayapiv1beta1.PathMatchType{gatewayapiv1beta1.PathMatchExact}[0],
+			Type:  &pathMatchType,
 			Value: &[]string{matchPath}[0],
 		},
 		Headers:     headersMatch,


### PR DESCRIPTION
# What

Kuadrant extensions for the Openapi 3.0.3 to add Gateway API HTTPRoute and Rate Limit Policy

## Info level kuadrant extension

Kuadrant extension that can be added at the info level of the OpenAPI spec.

```yaml
info:
  x-kuadrant:
    route:  ## HTTPRoute metadata
      name: "petstore"
      namespace: "petstore"
      labels:  ## map[string]string
        deployment: petstore
      hostnames:  ## []gateway.networking.k8s.io/v1beta1.Hostname
        - example.com
      parentRefs:  ## []gateway.networking.k8s.io/v1beta1.ParentReference
        - name: apiGateway
          namespace: gateways
```

## Path level kuadrant extension

Kuadrant extension that can be added at the path level of the OpenAPI spec.
This configuration at the path level is the default when there is no operation level configuration.

> What's new? `disable` field. Optional and defaults to `false`. This means, that unless explicitly excluded, all OpenAPI operations will be included in the HTTPRoute

> What's new? `pathMatchType` field. Specifies how to match against the path Value. Valid values: [Exact;PathPrefix]. Optional. Default: Exact

```yaml
paths:
  /cat:
    x-kuadrant:  ## Path level Kuadrant Extension
      disable: true  ## Remove from the HTTPRoute. Optional. Default: false
      pathMatchType: Exact ## Specifies how to match against the path Value. Valid values: [Exact;PathPrefix]. Optional. Default: Exact
      backendRefs:  ## Backend references to be included in the HTTPRoute. []gateway.networking.k8s.io/v1beta1.HTTPBackendRef. Optional.
        - name: petstore
          port: 80
          namespace: petstore
      rate_limit:  ## Rate limit config. Optional.
        rates:   ## Kuadrant API []github.com/kuadrant/kuadrant-operator/api/v1beta2.Rate
          - limit: 1
            duration: 10
            unit: second
        counters:   ## Kuadrant API []github.com/kuadrant/kuadrant-operator/api/v1beta2.CountextSelector
          - auth.identity.username
        when:   ## Kuadrant API []github.com/kuadrant/kuadrant-operator/api/v1beta2.WhenCondition
          - selector: metadata.filter_metadata.envoy\.filters\.http\.ext_authz.identity.userid
            operator: eq
            value: alice
```

## Operation level kuadrant extension

Kuadrant extension that can be added at the operation level of the OpenAPI spec.
Same schema as path level kuadrant extension.

> What's new? `disable` field. Optional and defaults to `false`. This means, that unless explicitly excluded, all OpenAPI operations will be included in the HTTPRoute

> What's new? `pathMatchType` field. Specifies how to match against the path Value. Valid values: [Exact;PathPrefix]. Optional. Default: Exact

```yaml
paths:
  /cat:
    get:
      x-kuadrant:  ## Path level Kuadrant Extension
        disable: true  ## Remove from the HTTPRoute. Optional. Default: path level "disable" value
        pathMatchType: Exact ## Specifies how to match against the path Value. Valid values: [Exact;PathPrefix]. Optional. Default: Exact
        backendRefs:  ## Backend references to be included in the HTTPRoute. Optional.
          - name: petstore
            port: 80
            namespace: petstore
        rate_limit:  ## Rate limit config. Optional.
          rates:   ## Kuadrant API github.com/kuadrant/kuadrant-operator/api/v1beta2.Rate
            - limit: 1
              duration: 10
              unit: second
          counters:   ## Kuadrant API github.com/kuadrant/kuadrant-operator/api/v1beta2.CountextSelector
            - auth.identity.username
          when:   ## Kuadrant API github.com/kuadrant/kuadrant-operator/api/v1beta2.WhenCondition
            - selector: metadata.filter_metadata.envoy\.filters\.http\.ext_authz.identity.userid
              operator: eq
              value: alice
```

OpenAPI doc example with the new extensions

```yaml
---
openapi: "3.0.3"
info:
  title: "Pet Store API"
  version: "1.0.0"
  x-kuadrant:
    route:
      name: "petstore"
      namespace: "petstore"
      labels:
        label1: "labelvalue1"
        label2: "labelvalue2"
      hostnames:
        - example.com
      parentRefs:
        - name: istio-ingressgateway
          namespace: istio-system
servers:
  - url: https://example.io/api/v1
paths:
  /cat:
    x-kuadrant:  ## Path level Kuadrant Extension
      backendRefs:
        - name: petstore
          port: 80
          namespace: petstore
      rate_limit:
        rates:
          - limit: 1
            duration: 10
            unit: second
        counters:
          - request.headers.x-forwarded-for
    get:  # Added to the route and rate limited
      operationId: "getCat"
      responses:
        405:
          description: "invalid input"
    post:  # NOT added to the route
      x-kuadrant:  ## Operation level Kuadrant Extension
        disable: true
        pathMatchType: PathPrefix
        backendRefs:
          - name: petstore
            port: 80
            namespace: petstore
        rate_limit:
          rates:
            - limit: 2
              duration: 10
              unit: second
          counters:
            - request.headers.x-forwarded-for
      operationId: "postCat"
      responses:
        405:
          description: "invalid input"
  /dog:
    get:  # Added to the route and rate limited
      x-kuadrant:  ## Operation level Kuadrant Extension
        backendRefs:
          - name: petstore
            port: 80
            namespace: petstore
        rate_limit:
          rates:
            - limit: 3
              duration: 10
              unit: second
          counters:
            - request.headers.x-forwarded-for
      operationId: "getDog"
      responses:
        405:
          description: "invalid input"
    post:  # Added to the route and NOT rate limited
      x-kuadrant:  ## Operation level Kuadrant Extension
        backendRefs:
          - name: petstore
            port: 80
            namespace: petstore
      operationId: "postDog"
      responses:
        405:
          description: "invalid input"
  /mouse:
    x-kuadrant:  ## Path level Kuadrant Extension
      disable: true
    get:  # NOT added to the route
      operationId: "getMouse"
      responses:
        405:
          description: "invalid input"
```