### PR TITLE
Some tidyup of links and usage guide wording for docs site

### DIFF
--- a/doc/generate-gateway-api-httproute.md
+++ b/doc/generate-gateway-api-httproute.md
@@ -1,13 +1,12 @@
 ## Generate Gateway API HTTPRoute object from OpenAPI 3
 
-The `kuadrantctl generate gatewayapi httproute` command generates an [Gateway API HTTPRoute](https://gateway-api.sigs.k8s.io/v1alpha2/guides/http-routing/)
-from your [OpenAPI Specification (OAS) 3.x](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md) powered with [kuadrant extensions](openapi-kuadrant-extensions.md).
+The `kuadrantctl generate gatewayapi httproute` command generates an [Gateway API HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/)
+from your [OpenAPI Specification (OAS) 3.x](https://spec.openapis.org/oas/latest.html) powered with [kuadrant extensions](openapi-kuadrant-extensions.md).
 
 ### OpenAPI specification
 
-[OpenAPI `v3.0`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md)
+An OpenAPI document resource can be provided to the cli by one of the following channels:
 
-OpenAPI document resource can be provided by one of the following channels:
 * Filename in the available path.
 * URL format (supported schemes are HTTP and HTTPS). The CLI will try to download from the given address.
 * Read from stdin standard input stream.
@@ -30,3 +29,10 @@ Global Flags:
 ```
 
 > Under the example folder there are examples of OAS 3 that can be used to generate the resources
+
+As an AuthPolicy and RateLimitPolicy both require a HTTPRoute to target, the user guides for generating those policies include examples of running the `kuadrantctl generate gatewayapi httproute` command.
+
+You can find those guides here:
+
+* [Generate Kuadrant AuthPolicy](./generate-kuadrant-auth-policy.md)
+* [Generate Kuadrant RateLimitPolicy](./generate-kuadrant-rate-limit-policy.md)

--- a/doc/generate-kuadrant-auth-policy.md
+++ b/doc/generate-kuadrant-auth-policy.md
@@ -1,18 +1,17 @@
 ## Generate Kuadrant AuthPolicy object from OpenAPI 3
 
-The `kuadrantctl generate kuadrant authpolicy` command generates an [Kuadrant AuthPolicy](https://github.com/Kuadrant/kuadrant-operator/blob/v0.4.1/doc/auth.md)
-from your [OpenAPI Specification (OAS) 3.x](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md) powered with [kuadrant extensions](openapi-kuadrant-extensions.md).
+The `kuadrantctl generate kuadrant authpolicy` command generates an [Kuadrant AuthPolicy](https://docs.kuadrant.io/kuadrant-operator/doc/auth/)
+from your [OpenAPI Specification (OAS) 3.x](https://spec.openapis.org/oas/latest.html) powered with [kuadrant extensions](openapi-kuadrant-extensions.md).
 
 ### OpenAPI specification
 
-[OpenAPI `v3.0`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md)
+An OpenAPI document resource can be provided to the cli by one of the following channels:
 
-OpenAPI document resource can be provided by one of the following channels:
 * Filename in the available path.
 * URL format (supported schemes are HTTP and HTTPS). The CLI will try to download from the given address.
 * Read from stdin standard input stream.
 
-OpenAPI [Security Scheme Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-scheme-object) types
+OpenAPI [Security Scheme Object](https://spec.openapis.org/oas/latest.html#security-scheme-object) types
 
 | Types | Implemented |
 | --- | --- |
@@ -415,7 +414,7 @@ curl  -H "Host: example.com" -H "api_key: I_LIKE_SNAKES" -X POST -i "http://127.
 ```
 
 ```
-TTP/1.1 401 Unauthorized
+HTTP/1.1 401 Unauthorized
 www-authenticate: Bearer realm="getDog_oidc"
 www-authenticate: Bearer realm="getSnake_oidc"
 www-authenticate: snake_token realm="getSnake_snakes_api_key"

--- a/doc/generate-kuadrant-rate-limit-policy.md
+++ b/doc/generate-kuadrant-rate-limit-policy.md
@@ -1,13 +1,12 @@
 ## Generate Kuadrant RateLimitPolicy object from OpenAPI 3
 
-The `kuadrantctl generate kuadrant ratelimitpolicy` command generates an [Kuadrant RateLimitPolicy](https://github.com/Kuadrant/kuadrant-operator/blob/v0.4.1/doc/rate-limiting.md)
-from your [OpenAPI Specification (OAS) 3.x](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md) powered with [kuadrant extensions](openapi-kuadrant-extensions.md).
+The `kuadrantctl generate kuadrant ratelimitpolicy` command generates an [Kuadrant RateLimitPolicy](https://docs.kuadrant.io/kuadrant-operator/doc/rate-limiting/)
+from your [OpenAPI Specification (OAS) 3.x](https://spec.openapis.org/oas/latest.html) powered with [kuadrant extensions](openapi-kuadrant-extensions.md).
 
 ### OpenAPI specification
 
-[OpenAPI `v3.0`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md)
+An OpenAPI document resource can be provided to the cli by one of the following channels:
 
-OpenAPI document resource can be provided by one of the following channels:
 * Filename in the available path.
 * URL format (supported schemes are HTTP and HTTPS). The CLI will try to download from the given address.
 * Read from stdin standard input stream.


### PR DESCRIPTION
Part of https://github.com/Kuadrant/kuadrantctl/issues/53
A docs site PR will follow to have sidenav links to the 3 pages added so they can be discovered more easily.

* Change links so they are less likely to be out of date
* Remove some redundant content
* Fixup start of lists for docs site formatting (see screenshot below of problem)
* Add link to usage guides from the HTTPRoute page to avoid duplicating usage guide content 

<img width="831" alt="image" src="https://github.com/Kuadrant/kuadrantctl/assets/878251/17642e64-313a-45f4-87f1-11bee731c591">
