### PR TITLE
SIGSEGV on generating resources with a spec without x-kuadrant extensions

### DIFF
--- a/pkg/gatewayapi/http_route.go
+++ b/pkg/gatewayapi/http_route.go
@@ -19,6 +19,10 @@ func HTTPRouteObjectMetaFromOAS(doc *openapi3.T) metav1.ObjectMeta {
 		panic(err)
 	}
 
+	if kuadrantInfoExtension == nil {
+		return metav1.ObjectMeta{}
+	}
+
 	if kuadrantInfoExtension.Route == nil {
 		panic("info kuadrant extension route not found")
 	}
@@ -45,8 +49,13 @@ func HTTPRouteGatewayParentRefsFromOAS(doc *openapi3.T) []gatewayapiv1beta1.Pare
 	}
 
 	kuadrantInfoExtension, err := utils.NewKuadrantOASInfoExtension(doc.Info)
+
 	if err != nil {
 		panic(err)
+	}
+
+	if kuadrantInfoExtension == nil {
+		return nil
 	}
 
 	if kuadrantInfoExtension.Route == nil {
@@ -64,6 +73,10 @@ func HTTPRouteHostnamesFromOAS(doc *openapi3.T) []gatewayapiv1beta1.Hostname {
 	kuadrantInfoExtension, err := utils.NewKuadrantOASInfoExtension(doc.Info)
 	if err != nil {
 		panic(err)
+	}
+
+	if kuadrantInfoExtension == nil {
+		return nil
 	}
 
 	if kuadrantInfoExtension.Route == nil {


### PR DESCRIPTION
Quick fix to resolve a small bug:

https://github.com/Kuadrant/kuadrantctl/issues/64

We could make this more complex by detecting the many permutations of inclusion of `x-kuadrant` extensions in specs, to warn/panic if none are found. That may be a better fix longer term (could be addressed this way as a follow-on PR if needs be - this gets us out of a hole right now).


### Verifying

```bash
# With kuadrantctl 0.2.0
kuadrantctl generate kuadrant authpolicy --oas ./examples/oas3/petstore.yaml
```

=>

```
big old SIGSEGV
```

With this patch, no panic.

Have also patched `HTTPRouteGatewayParentRefsFromOAS` and `HTTPRouteHostnamesFromOAS` which have a similar bug.