### PR TITLE
Resource generation - default to yaml, add option for output formats (JSON or YAML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Generate Gateway API resources from an OpenAPI 3.x specification
 
 | Subcommand | Description                                      | Flags                             |
 | ---------- | ------------------------------------------------ | --------------------------------- |
-| `httproute`| Generate Gateway API HTTPRoute from OpenAPI 3.0.X| `--oas string` Path or URL to OpenAPI spec (required) |
+| `httproute`| Generate Gateway API HTTPRoute from OpenAPI 3.0.X| `--oas string` Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required). `-o` Output format: 'yaml' or 'json'. Default: yaml |
 
 ##### `generate kuadrant`
 
@@ -88,8 +88,8 @@ Generate Kuadrant resources from an OpenAPI 3.x specification
 
 | Subcommand       | Description                                       | Flags                             |
 | ---------------- | ------------------------------------------------- | --------------------------------- |
-| `authpolicy`     | Generate a [Kuadrant AuthPolicy](https://docs.kuadrant.io/kuadrant-operator/doc/auth/) from an OpenAPI 3.0.x specification   | `--oas string` Path or URL to OpenAPI spec (required) |
-| `ratelimitpolicy`| Generate [Kuadrant RateLimitPolicy](https://docs.kuadrant.io/kuadrant-operator/doc/rate-limiting/) from an OpenAPI 3.0.x specification | `--oas string` Path or URL to OpenAPI spec (required) |
+| `authpolicy`     | Generate a [Kuadrant AuthPolicy](https://docs.kuadrant.io/kuadrant-operator/doc/auth/) from an OpenAPI 3.0.x specification   | `--oas string` Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required). `-o` Output format: 'yaml' or 'json'. Default: yaml |
+| `ratelimitpolicy`| Generate [Kuadrant RateLimitPolicy](https://docs.kuadrant.io/kuadrant-operator/doc/rate-limiting/) from an OpenAPI 3.0.x specification | `--oas string` Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required). `-o` Output format: 'yaml' or 'json'. Default: yaml |
 
 
 #### `install`

--- a/cmd/generate_gatewayapi_httproute.go
+++ b/cmd/generate_gatewayapi_httproute.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	generateGatewayAPIHTTPRouteOAS string
+	generateGatewayAPIHTTPRouteOAS    string
+	generateGatewayAPIHTTPRouteFormat string
 )
 
 //kuadrantctl generate gatewayapi httproute --oas [OAS_FILE_PATH | OAS_URL | @]
@@ -24,24 +25,12 @@ func generateGatewayApiHttpRouteCommand() *cobra.Command {
 		Use:   "httproute",
 		Short: "Generate Gateway API HTTPRoute from OpenAPI 3.0.X",
 		Long:  "Generate Gateway API HTTPRoute from OpenAPI 3.0.X",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			outputFormat, err := cmd.Flags().GetString("output-format")
-			if err != nil {
-				return err
-			}
-
-			oasPath, err := cmd.Flags().GetString("oas")
-			if err != nil {
-				return err
-			}
-
-			return runGenerateGatewayApiHttpRoute(cmd, oasPath, outputFormat)
-		},
+		RunE:  runGenerateGatewayApiHttpRoute,
 	}
 
 	// OpenAPI ref
 	cmd.Flags().StringVar(&generateGatewayAPIHTTPRouteOAS, "oas", "", "Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)")
-	cmd.Flags().StringP("output-format", "o", "yaml", "Output format: 'yaml' or 'json'. Default: yaml")
+	cmd.Flags().StringVarP(&generateGatewayAPIHTTPRouteFormat, "output-format", "o", "yaml", "Output format: 'yaml' or 'json'. Default: yaml")
 	err := cmd.MarkFlagRequired("oas")
 	if err != nil {
 		panic(err)
@@ -50,8 +39,8 @@ func generateGatewayApiHttpRouteCommand() *cobra.Command {
 	return cmd
 }
 
-func runGenerateGatewayApiHttpRoute(cmd *cobra.Command, oasPath, outputFormat string) error {
-	oasDataRaw, err := utils.ReadExternalResource(oasPath)
+func runGenerateGatewayApiHttpRoute(cmd *cobra.Command, args []string) error {
+	oasDataRaw, err := utils.ReadExternalResource(generateGatewayAPIHTTPRouteOAS)
 	if err != nil {
 		return err
 	}
@@ -70,7 +59,7 @@ func runGenerateGatewayApiHttpRoute(cmd *cobra.Command, oasPath, outputFormat st
 	httpRoute := buildHTTPRoute(doc)
 
 	var outputBytes []byte
-	if outputFormat == "json" {
+	if generateGatewayAPIHTTPRouteFormat == "json" {
 		outputBytes, err = json.Marshal(httpRoute)
 	} else { // default to YAML if not explicitly JSON
 		outputBytes, err = yaml.Marshal(httpRoute)

--- a/cmd/generate_gatewayapi_httproute.go
+++ b/cmd/generate_gatewayapi_httproute.go
@@ -27,7 +27,7 @@ func generateGatewayApiHttpRouteCommand() *cobra.Command {
 	}
 
 	// OpenAPI ref
-	cmd.Flags().StringVar(&generateGatewayAPIHTTPRouteOAS, "oas", "", "/path/to/file.[json|yaml|yml] OR http[s]://domain/resource/path.[json|yaml|yml] OR @ (required)")
+	cmd.Flags().StringVar(&generateGatewayAPIHTTPRouteOAS, "oas", "", "Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)")
 	err := cmd.MarkFlagRequired("oas")
 	if err != nil {
 		panic(err)

--- a/cmd/generate_kuadrant_authpolicy.go
+++ b/cmd/generate_kuadrant_authpolicy.go
@@ -27,7 +27,7 @@ func generateKuadrantAuthPolicyCommand() *cobra.Command {
 	}
 
 	// OpenAPI ref
-	cmd.Flags().StringVar(&generateGatewayAPIHTTPRouteOAS, "oas", "", "/path/to/file.[json|yaml|yml] OR http[s]://domain/resource/path.[json|yaml|yml] OR @ (required)")
+	cmd.Flags().StringVar(&generateGatewayAPIHTTPRouteOAS, "oas", "", "Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)")
 	err := cmd.MarkFlagRequired("oas")
 	if err != nil {
 		panic(err)

--- a/cmd/generate_kuadrant_authpolicy.go
+++ b/cmd/generate_kuadrant_authpolicy.go
@@ -17,6 +17,11 @@ import (
 	"github.com/kuadrant/kuadrantctl/pkg/utils"
 )
 
+var (
+	generateAuthPolicyOAS    string
+	generateAuthPolicyFormat string
+)
+
 //kuadrantctl generate kuadrant authpolicy --oas [OAS_FILE_PATH | OAS_URL | @]
 
 func generateKuadrantAuthPolicyCommand() *cobra.Command {
@@ -24,24 +29,12 @@ func generateKuadrantAuthPolicyCommand() *cobra.Command {
 		Use:   "authpolicy",
 		Short: "Generate Kuadrant AuthPolicy from OpenAPI 3.0.X",
 		Long:  "Generate Kuadrant AuthPolicy from OpenAPI 3.0.X",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			outputFormat, err := cmd.Flags().GetString("output-format")
-			if err != nil {
-				return err
-			}
-
-			oasPath, err := cmd.Flags().GetString("oas")
-			if err != nil {
-				return err
-			}
-
-			return runGenerateKuadrantAuthPolicy(cmd, oasPath, outputFormat)
-		},
+		RunE:  runGenerateKuadrantAuthPolicy,
 	}
 
 	// OpenAPI ref
-	cmd.Flags().StringVar(&generateGatewayAPIHTTPRouteOAS, "oas", "", "Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)")
-	cmd.Flags().StringP("output-format", "o", "yaml", "Output format: 'yaml' or 'json'. Default: yaml")
+	cmd.Flags().StringVar(&generateAuthPolicyOAS, "oas", "", "Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)")
+	cmd.Flags().StringVarP(&generateAuthPolicyFormat, "output-format", "o", "yaml", "Output format: 'yaml' or 'json'. Default: yaml")
 	err := cmd.MarkFlagRequired("oas")
 	if err != nil {
 		panic(err)
@@ -50,8 +43,8 @@ func generateKuadrantAuthPolicyCommand() *cobra.Command {
 	return cmd
 }
 
-func runGenerateKuadrantAuthPolicy(cmd *cobra.Command, oasPath, outputFormat string) error {
-	oasDataRaw, err := utils.ReadExternalResource(oasPath)
+func runGenerateKuadrantAuthPolicy(cmd *cobra.Command, args []string) error {
+	oasDataRaw, err := utils.ReadExternalResource(generateAuthPolicyOAS)
 	if err != nil {
 		return err
 	}
@@ -70,7 +63,7 @@ func runGenerateKuadrantAuthPolicy(cmd *cobra.Command, oasPath, outputFormat str
 	ap := buildAuthPolicy(doc)
 
 	var outputBytes []byte
-	if outputFormat == "json" {
+	if generateAuthPolicyFormat == "json" {
 		outputBytes, err = json.Marshal(ap)
 	} else { // default to YAML if not explicitly JSON
 		outputBytes, err = yaml.Marshal(ap)

--- a/cmd/generate_kuadrant_authpolicy.go
+++ b/cmd/generate_kuadrant_authpolicy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	kuadrantapiv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapiv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -23,11 +24,24 @@ func generateKuadrantAuthPolicyCommand() *cobra.Command {
 		Use:   "authpolicy",
 		Short: "Generate Kuadrant AuthPolicy from OpenAPI 3.0.X",
 		Long:  "Generate Kuadrant AuthPolicy from OpenAPI 3.0.X",
-		RunE:  runGenerateKuadrantAuthPolicy,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat, err := cmd.Flags().GetString("output-format")
+			if err != nil {
+				return err
+			}
+
+			oasPath, err := cmd.Flags().GetString("oas")
+			if err != nil {
+				return err
+			}
+
+			return runGenerateKuadrantAuthPolicy(cmd, oasPath, outputFormat)
+		},
 	}
 
 	// OpenAPI ref
 	cmd.Flags().StringVar(&generateGatewayAPIHTTPRouteOAS, "oas", "", "Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)")
+	cmd.Flags().StringP("output-format", "o", "yaml", "Output format: 'yaml' or 'json'. Default: yaml")
 	err := cmd.MarkFlagRequired("oas")
 	if err != nil {
 		panic(err)
@@ -36,8 +50,8 @@ func generateKuadrantAuthPolicyCommand() *cobra.Command {
 	return cmd
 }
 
-func runGenerateKuadrantAuthPolicy(cmd *cobra.Command, args []string) error {
-	oasDataRaw, err := utils.ReadExternalResource(generateGatewayAPIHTTPRouteOAS)
+func runGenerateKuadrantAuthPolicy(cmd *cobra.Command, oasPath, outputFormat string) error {
+	oasDataRaw, err := utils.ReadExternalResource(oasPath)
 	if err != nil {
 		return err
 	}
@@ -55,12 +69,17 @@ func runGenerateKuadrantAuthPolicy(cmd *cobra.Command, args []string) error {
 
 	ap := buildAuthPolicy(doc)
 
-	jsonData, err := json.Marshal(ap)
+	var outputBytes []byte
+	if outputFormat == "json" {
+		outputBytes, err = json.Marshal(ap)
+	} else { // default to YAML if not explicitly JSON
+		outputBytes, err = yaml.Marshal(ap)
+	}
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintln(cmd.OutOrStdout(), string(jsonData))
+	fmt.Fprintln(cmd.OutOrStdout(), string(outputBytes))
 	return nil
 }
 

--- a/cmd/generate_kuadrant_ratelimitpolicy.go
+++ b/cmd/generate_kuadrant_ratelimitpolicy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	kuadrantapiv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
@@ -19,13 +20,11 @@ import (
 
 //kuadrantctl generate kuadrant ratelimitpolicy --oas [OAS_FILE_PATH | OAS_URL | @]
 
-// var outputFormat string
-
 func generateKuadrantRateLimitPolicyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ratelimitpolicy",
-		Short: "Generate Kuadrant RateLimitPolicy from OpenAPI 3.0.X",
-		Long:  "Generate Kuadrant RateLimitPolicy from OpenAPI 3.0.X",
+		Short: "Generate Kuadrant Rate Limit Policy from OpenAPI 3.0.X",
+		Long:  "Generate Kuadrant Rate Limit Policy from OpenAPI 3.0.X",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat, err := cmd.Flags().GetString("output-format")
 			if err != nil {
@@ -43,7 +42,11 @@ func generateKuadrantRateLimitPolicyCommand() *cobra.Command {
 
 	cmd.Flags().String("oas", "", "Path to OpenAPI spec file (in JSON or YAML format) or URL (required)")
 	cmd.Flags().StringP("output-format", "o", "yaml", "Output format: 'yaml' or 'json'. Default: yaml")
-	cmd.MarkFlagRequired("oas")
+
+	if err := cmd.MarkFlagRequired("oas"); err != nil {
+		fmt.Println("Error setting 'oas' flag as required:", err)
+		os.Exit(1)
+	}
 
 	return cmd
 }

--- a/doc/generate-gateway-api-httproute.md
+++ b/doc/generate-gateway-api-httproute.md
@@ -21,8 +21,9 @@ Usage:
   kuadrantctl generate gatewayapi httproute [flags]
 
 Flags:
-  -h, --help         help for httproute
-      --oas string   /path/to/file.[json|yaml|yml] OR http[s]://domain/resource/path.[json|yaml|yml] OR @ (required)
+  -h, --help          help for httproute
+  --oas string        Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)
+  -o Output format:   'yaml' or 'json'. Default: yaml
 
 Global Flags:
   -v, --verbose   verbose output

--- a/doc/generate-kuadrant-auth-policy.md
+++ b/doc/generate-kuadrant-auth-policy.md
@@ -172,7 +172,8 @@ Usage:
 
 Flags:
   -h, --help         help for authpolicy
-      --oas string   /path/to/file.[json|yaml|yml] OR http[s]://domain/resource/path.[json|yaml|yml] OR @ (required)
+  --oas string        Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)
+  -o Output format:   'yaml' or 'json'. Default: yaml
 
 Global Flags:
   -v, --verbose   verbose output

--- a/doc/generate-kuadrant-rate-limit-policy.md
+++ b/doc/generate-kuadrant-rate-limit-policy.md
@@ -21,7 +21,8 @@ Usage:
 
 Flags:
   -h, --help         help for ratelimitpolicy
-      --oas string   /path/to/file.[json|yaml|yml] OR http[s]://domain/resource/path.[json|yaml|yml] OR @ (required)
+  --oas string        Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)
+  -o Output format:   'yaml' or 'json'. Default: yaml
 
 Global Flags:
   -v, --verbose   verbose output

--- a/pkg/utils/external_resource_reader.go
+++ b/pkg/utils/external_resource_reader.go
@@ -21,11 +21,11 @@ import (
 )
 
 // ReadExternalResource reads data streams from external resources. Currently implemented:
-// - '@' for STDIN
+// - '-' or '@' for STDIN
 // - URLs (HTTP[S])
 // - Files
 func ReadExternalResource(resource string) ([]byte, error) {
-	if resource == "@" {
+	if resource == "-" || resource == "@" {
 		return io.ReadAll(os.Stdin)
 	}
 


### PR DESCRIPTION
- Resource generation output format options - default to `yaml`, add option for output formats (JSON or YAML)
- Associated docs

## Verify

1. Build locally:

`go build` or one of the make targets

2. Sample generation commands:

```
./kuadrantctl generate gatewayapi httproute --oas examples/oas3/petstore.yaml # defaults to yaml
./kuadrantctl generate gatewayapi httproute --oas examples/oas3/petstore.yaml -o json
./kuadrantctl generate kuadrant ratelimitpolicy --oas examples/oas3/petstore.yaml
./kuadrantctl generate kuadrant authpolicy --oas examples/oas3/petstore-with-oidc-kuadrant-extensions.yaml
./kuadrantctl generate kuadrant ratelimitpolicy --oas examples/oas3/petstore-with-rate-limit-kuadrant-extensions.yaml

# via stdin
cat examples/oas3/petstore-with-rate-limit-kuadrant-extensions.yaml | ./kuadrantctl generate kuadrant ratelimitpolicy --oas -
cat examples/oas3/petstore-with-rate-limit-kuadrant-extensions.yaml | envsubst | ./kuadrantctl generate kuadrant ratelimitpolicy --oas -
```