### PR TITLE
reduce yaml output verbosity

### DIFF
--- a/cmd/generate_gatewayapi_httproute.go
+++ b/cmd/generate_gatewayapi_httproute.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/ghodss/yaml"
 	"github.com/kuadrant/kuadrantctl/pkg/gatewayapi"
 	"github.com/kuadrant/kuadrantctl/pkg/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapiv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -57,15 +57,19 @@ func runGenerateGatewayApiHttpRoute(cmd *cobra.Command, args []string) error {
 	}
 
 	httpRoute := buildHTTPRoute(doc)
+	jsonBytes, err := json.Marshal(httpRoute)
+	if err != nil {
+		return err
+	}
 
 	var outputBytes []byte
 	if generateGatewayAPIHTTPRouteFormat == "json" {
-		outputBytes, err = json.Marshal(httpRoute)
-	} else { // default to YAML if not explicitly JSON
-		outputBytes, err = yaml.Marshal(httpRoute)
-	}
-	if err != nil {
-		return err
+		outputBytes = jsonBytes
+	} else {
+		outputBytes, err = yaml.JSONToYAML(jsonBytes) // use `omitempty`'s from the json Marshal
+		if err != nil {
+			return err
+		}
 	}
 
 	fmt.Fprintln(cmd.OutOrStdout(), string(outputBytes))

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.7.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/getkin/kin-openapi v0.120.0 h1:MqJcNJFrMDFNc07iwE8iFC5eT2k/NPUFDIpNeiZv8Jg=
 github.com/getkin/kin-openapi v0.120.0/go.mod h1:PCWw/lfBrJY4HcdqE3jj+QFkaFK8ABoqo7PvqVhXXqw=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
Reducing `yaml` output verbosity (similar to the JSON output, which uses omit's empties)

Before:

```bash
./kuadrantctl generate gatewayapi httproute -o yaml --oas examples/oas3/petstore-with-rate-limit-kuadrant-extensions.yaml
typemeta:
  kind: HTTPRoute
  apiversion: gateway.networking.k8s.io/v1beta1
objectmeta:
  name: petstore
  generatename: ""
  namespace: petstore
  selflink: ""
  uid: ""
  resourceversion: ""
  generation: 0
  creationtimestamp: "0001-01-01T00:00:00Z"
  deletiontimestamp: null
  deletiongraceperiodseconds: null
  labels: {}
  annotations: {}
  ownerreferences: []
  finalizers: []
  managedfields: []
spec:
  commonroutespec:
    parentrefs:
    - group: null
      kind: null
      namespace: istio-system
      name: istio-ingressgateway
      sectionname: null
      port: null
  hostnames:
  - example.com
  rules:
  - matches:
    - path:
        type: Exact
        value: /api/v1/cat
      headers: []
      queryparams: []
      method: GET
    filters: []
    backendrefs:
    - backendref:
        backendobjectreference:
          group: null
          kind: null
          name: petstore
          namespace: petstore
          port: 80
        weight: null
      filters: []
  - matches:
    - path:
        type: Exact
        value: /api/v1/dog
      headers: []
      queryparams: []
      method: GET
    filters: []
    backendrefs:
    - backendref:
        backendobjectreference:
          group: null
          kind: null
          name: petstore
          namespace: petstore
          port: 80
        weight: null
      filters: []
  - matches:
    - path:
        type: Exact
        value: /api/v1/dog
      headers: []
      queryparams: []
      method: POST
    filters: []
    backendrefs:
    - backendref:
        backendobjectreference:
          group: null
          kind: null
          name: petstore
          namespace: petstore
          port: 80
        weight: null
      filters: []
status:
  routestatus:
    parents: []
```

After:

```bash
./kuadrantctl generate gatewayapi httproute -o yaml --oas examples/oas3/petstore-with-rate-limit-kuadrant-extensions.yaml
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  creationTimestamp: null
  name: petstore
  namespace: petstore
spec:
  hostnames:
  - example.com
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  rules:
  - backendRefs:
    - name: petstore
      namespace: petstore
      port: 80
    matches:
    - method: GET
      path:
        type: Exact
        value: /api/v1/cat
  - backendRefs:
    - name: petstore
      namespace: petstore
      port: 80
    matches:
    - method: POST
      path:
        type: Exact
        value: /api/v1/dog
  - backendRefs:
    - name: petstore
      namespace: petstore
      port: 80
    matches:
    - method: GET
      path:
        type: Exact
        value: /api/v1/dog
status:
  parents: null
```