### PR TITLE
Autpolicy doc fixes

### DIFF
--- a/doc/generate-kuadrant-auth-policy.md
+++ b/doc/generate-kuadrant-auth-policy.md
@@ -318,6 +318,7 @@ EOF
 > Replace `${KEYCLOAK_PUBLIC_DOMAIN}` with your SSO instance domain
 
 * Create an API key only valid for `POST /api/v1/cat` endpoint
+
 ```yaml
 kubectl apply -f -<<EOF
 apiVersion: v1
@@ -333,6 +334,7 @@ stringData:
 type: Opaque
 EOF
 ```
+
 > **Note**: the label's value of `kuadrant.io/apikeys-by: cat_api_key` is the name of the sec scheme of the OpenAPI spec.
 
 * Create an API key only valid for `GET /api/v1/snake` endpoint

--- a/doc/generate-kuadrant-auth-policy.md
+++ b/doc/generate-kuadrant-auth-policy.md
@@ -25,6 +25,10 @@ OpenAPI [Security Scheme Object](https://spec.openapis.org/oas/latest.html#secur
 The following OAS example has one protected endpoint `GET /dog` with `openIdConnect` security scheme type.
 
 ```yaml
+openapi: "3.1.0"
+info:
+  title: "Pet Store API"
+  version: "1.0.0"
 paths:
   /dog:
     get:
@@ -41,10 +45,10 @@ components:
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
 ```
 
-Running the command
+Take this example and save it as `example.yaml` and than run the command:
 
-```
-kuadrantctl generate kuadrant authpolicy --oas ./petstore-openapi.yaml  | yq -P
+```bash
+kuadrantctl generate kuadrant authpolicy --oas example.yaml
 ```
 
 The generated authpolicy (only relevan fields shown here):
@@ -52,10 +56,6 @@ The generated authpolicy (only relevan fields shown here):
 ```yaml
 kind: AuthPolicy
 apiVersion: kuadrant.io/v1beta2
-metadata:
-  name: petstore
-  namespace: petstore
-  creationTimestamp: null
 spec:
   routeSelectors:
     - matches:
@@ -82,6 +82,10 @@ spec:
 The following OAS example has one protected endpoint `GET /dog` with `apiKey` security scheme type.
 
 ```yaml
+openapi: "3.1.0"
+info:
+  title: "Pet Store API"
+  version: "1.0.0"
 paths:
   /dog:
     get:
@@ -99,10 +103,10 @@ components:
       in: query
 ```
 
-Running the command
+Take this example and save it as `example.yaml` and than run the command:
 
-```
-kuadrantctl generate kuadrant authpolicy --oas ./petstore-openapi.yaml  | yq -P
+```bash
+kuadrantctl generate kuadrant authpolicy --oas example.yaml
 ```
 
 The generated authpolicy (only relevan fields shown here):
@@ -110,10 +114,6 @@ The generated authpolicy (only relevan fields shown here):
 ```yaml
 kind: AuthPolicy
 apiVersion: kuadrant.io/v1beta2
-metadata:
-  name: petstore
-  namespace: petstore
-  creationTimestamp: null
 spec:
   routeSelectors:
     - matches:


### PR DESCRIPTION
Contains fixes:
- The openapi examples are now in proper openapi yaml format
- Redundant `yq` removal
- Added Gateway object creation otherwise HttpRoute will not have parent
   - Due to this a random IP is assigned so a new variable `INGRESS_IP` is needed for curl examples
- Refactor SSO urls in examples
- Fix Direct access grant alternative name
- Fix some spacing and other small refactors