### PR TITLE
removed redundant default yaml output and adjusted docs to reflect new changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Generate Gateway API resources from an OpenAPI 3.x specification
 
 | Subcommand | Description                                      | Flags                             |
 | ---------- | ------------------------------------------------ | --------------------------------- |
-| `httproute`| Generate Gateway API HTTPRoute from OpenAPI 3.0.X| `--oas string` Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required). `-o` Output format: 'yaml' or 'json'. Default: yaml |
+| `httproute`| Generate Gateway API HTTPRoute from OpenAPI 3.0.X| `--oas string` Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required). `-o` Output format: 'yaml' or 'json'. (default "yaml") |
 
 ##### `generate kuadrant`
 
@@ -86,8 +86,8 @@ Generate Kuadrant resources from an OpenAPI 3.x specification
 
 | Subcommand       | Description                                       | Flags                             |
 | ---------------- | ------------------------------------------------- | --------------------------------- |
-| `authpolicy`     | Generate a [Kuadrant AuthPolicy](https://docs.kuadrant.io/kuadrant-operator/doc/auth/) from an OpenAPI 3.0.x specification   | `--oas string` Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required). `-o` Output format: 'yaml' or 'json'. Default: yaml |
-| `ratelimitpolicy`| Generate [Kuadrant RateLimitPolicy](https://docs.kuadrant.io/kuadrant-operator/doc/rate-limiting/) from an OpenAPI 3.0.x specification | `--oas string` Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required). `-o` Output format: 'yaml' or 'json'. Default: yaml |
+| `authpolicy`     | Generate a [Kuadrant AuthPolicy](https://docs.kuadrant.io/kuadrant-operator/doc/auth/) from an OpenAPI 3.0.x specification   | `--oas string` Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required). `-o` Output format: 'yaml' or 'json'. (default "yaml") |
+| `ratelimitpolicy`| Generate [Kuadrant RateLimitPolicy](https://docs.kuadrant.io/kuadrant-operator/doc/rate-limiting/) from an OpenAPI 3.0.x specification | `--oas string` Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required). `-o` Output format: 'yaml' or 'json'. (default "yaml") |
 
 
 #### `version`

--- a/cmd/generate_gatewayapi_httproute.go
+++ b/cmd/generate_gatewayapi_httproute.go
@@ -30,7 +30,7 @@ func generateGatewayApiHttpRouteCommand() *cobra.Command {
 
 	// OpenAPI ref
 	cmd.Flags().StringVar(&generateGatewayAPIHTTPRouteOAS, "oas", "", "Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)")
-	cmd.Flags().StringVarP(&generateGatewayAPIHTTPRouteFormat, "output-format", "o", "yaml", "Output format: 'yaml' or 'json'. Default: yaml")
+	cmd.Flags().StringVarP(&generateGatewayAPIHTTPRouteFormat, "output-format", "o", "yaml", "Output format: 'yaml' or 'json'.")
 	err := cmd.MarkFlagRequired("oas")
 	if err != nil {
 		panic(err)

--- a/cmd/generate_kuadrant_authpolicy.go
+++ b/cmd/generate_kuadrant_authpolicy.go
@@ -34,7 +34,7 @@ func generateKuadrantAuthPolicyCommand() *cobra.Command {
 
 	// OpenAPI ref
 	cmd.Flags().StringVar(&generateAuthPolicyOAS, "oas", "", "Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)")
-	cmd.Flags().StringVarP(&generateAuthPolicyFormat, "output-format", "o", "yaml", "Output format: 'yaml' or 'json'. Default: yaml")
+	cmd.Flags().StringVarP(&generateAuthPolicyFormat, "output-format", "o", "yaml", "Output format: 'yaml' or 'json'.")
 	err := cmd.MarkFlagRequired("oas")
 	if err != nil {
 		panic(err)

--- a/cmd/generate_kuadrant_ratelimitpolicy.go
+++ b/cmd/generate_kuadrant_ratelimitpolicy.go
@@ -35,7 +35,7 @@ func generateKuadrantRateLimitPolicyCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&generateRateLimitPolicyOAS, "oas", "", "Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)")
-	cmd.Flags().StringVarP(&generateRateLimitPolicyFormat, "output-format", "o", "yaml", "Output format: 'yaml' or 'json'. Default: yaml")
+	cmd.Flags().StringVarP(&generateRateLimitPolicyFormat, "output-format", "o", "yaml", "Output format: 'yaml' or 'json'.")
 
 	if err := cmd.MarkFlagRequired("oas"); err != nil {
 		fmt.Println("Error setting 'oas' flag as required:", err)

--- a/doc/generate-gateway-api-httproute.md
+++ b/doc/generate-gateway-api-httproute.md
@@ -23,7 +23,7 @@ Usage:
 Flags:
   -h, --help          help for httproute
   --oas string        Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)
-  -o Output format:   'yaml' or 'json'. Default: yaml
+  -o Output format:   'yaml' or 'json'. (default "yaml")
 
 Global Flags:
   -v, --verbose   verbose output

--- a/doc/generate-kuadrant-auth-policy.md
+++ b/doc/generate-kuadrant-auth-policy.md
@@ -173,7 +173,7 @@ Usage:
 Flags:
   -h, --help         help for authpolicy
   --oas string        Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)
-  -o Output format:   'yaml' or 'json'. Default: yaml
+  -o Output format:   'yaml' or 'json'. (default "yaml")
 
 Global Flags:
   -v, --verbose   verbose output

--- a/doc/generate-kuadrant-rate-limit-policy.md
+++ b/doc/generate-kuadrant-rate-limit-policy.md
@@ -22,7 +22,7 @@ Usage:
 Flags:
   -h, --help         help for ratelimitpolicy
   --oas string        Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)
-  -o Output format:   'yaml' or 'json'. Default: yaml
+  -o Output format:   'yaml' or 'json'. (default "yaml")
 
 Global Flags:
   -v, --verbose   verbose output


### PR DESCRIPTION
In relation to #75 .

### What:
- removed redundant default yaml output and adjusted docs to reflect new changes

### Verify: 
To verify, compile binary from root directory on this branch using `go build` and run the following commands:

```bash
./kuadrantctl generate gatewayapi httproute --help
./kuadrantctl generate kuadrant authpolicy --help
./kuadrantctl generate kuadrant ratelimitpolicy --help
```

Verify that there is no longer any redundant yaml output as mentioned in #75 . Also verify that the docs changed don't mention the redundant default yaml ouput anymore. 