### PR TITLE
changed version from latest to v0.0.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@ limitations under the License.
 package version
 
 var (
-	Version = "latest"
+	Version = "v0.0.0"
 )


### PR DESCRIPTION
### What:

- Version in `version/version.go` has been changed from "latest" to "v0.0.0" to align better with how versions are displayed in kuadrant-operator when compiling non-releases. Change requested by @azgabur . 

### Verify: 

- run `go build` in root directory of repo, followed by `./kuadrantctl version` which should give the following ouput:

```
{"level":"info","ts":"2024-05-21T15:50:49+01:00","msg":"kuadrantctl version: v0.0.0"}
```