### PR TITLE
Refactor version display

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/kuadrant/kuadrantctl/pkg/utils"
 	"github.com/kuadrant/kuadrantctl/version"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func versionCommand() *cobra.Command {
@@ -21,7 +20,7 @@ func versionCommand() *cobra.Command {
 				return err
 			}
 
-			logf.Log.Info(fmt.Sprintf("kuadrantctl version: %s", version.Version))
+			fmt.Println("kuadrantctl", version.Version)
 			return nil
 		},
 	}


### PR DESCRIPTION
Currently the kuadrantctl version is printed as a log message on `stderr`. This change will simplify the version string and make it print out on `stdout`.
Old:
```bash
$ kuadrantctl version
{"level":"info","ts":"2024-06-04T17:04:46+02:00","msg":"kuadrantctl version: v0.0.0"}
```
New:
```bash
$ kuadrantctl version
kuadrantctl v0.0.0
```