### PR TITLE
versioning in releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,11 @@ jobs:
         goos: [linux, darwin]
         goarch: [amd64, arm64]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: wangyoucao577/go-release-action@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         goversion: 1.21.4
+        ldflags: -X "github.com/kuadrant/kuadrantctl/version.GitHash=${{ github.sha }}"


### PR DESCRIPTION
### What 

Have the `GitHash` filled for release binaries

### Verification steps

Download binary from release asset and run `kuadrantctl version` command. It should be something like:

```bash
wget https://github.com/Kuadrant/kuadrantctl/releases/download/v0.2.4-alpha1/kuadrantctl-v0.2.4-alpha1-linux-amd64.tar.gz

tar zxfv kuadrantctl-v0.2.4-alpha1-linux-amd64.tar.gz

./kuadrantctl version
```

The response being:

```
kuadrantctl v0.2.4-alpha1 (01007cb359e24c0f59fdf7e9f7a41aec1f00b240)
```
