### PR TITLE
makefile enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,32 @@
 SHELL := /bin/bash
 
-MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+MKFILE_PATH := $(abspath $(firstword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 GO ?= go
 
 all: help
 
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
 .PHONY : help
-help: Makefile
-	@sed -n 's/^##//p' $<
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-# Ginkgo tool
-GINKGO = $(PROJECT_PATH)/bin/ginkgo
-$(GINKGO):
-	# In order to make sure the version of the ginkgo cli installed
-	# is the same as the version of go.mod,
-	# instead of calling go-install-tool,
-	# running go install from the current module will pick version from current go.mod file.
-	GOBIN=$(PROJECT_PATH)/bin go install github.com/onsi/ginkgo/v2/ginkgo
+include ./make/tools/*.mk
 
-.PHONY: ginkgo
-ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.
+##@ Development
 
-KIND = $(PROJECT_PATH)/bin/kind
-KIND_VERSION = v0.22.0
-$(KIND):
-	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@$(KIND_VERSION))
-
-.PHONY: kind
-kind: $(KIND) ## Download kind locally if necessary.
-
-KUSTOMIZE = $(PROJECT_PATH)/bin/kustomize
-$(KUSTOMIZE):
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.5)
-
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-
-## test: Run unit tests
 .PHONY : test
-test: clean-cov fmt vet $(GINKGO)
+test: clean-cov fmt vet $(GINKGO) ## Run unit tests
 	mkdir -p $(PROJECT_PATH)/coverage
 	# Shuffle both the order in which specs within a suite run, and the order in which different suites run
 	# You can always rerun a given ordering later by passing the --seed flag a matching seed.
@@ -51,9 +38,9 @@ test: clean-cov fmt vet $(GINKGO)
 		--coverprofile cover.out \
 		./pkg/... ./cmd/...
 
-## install: Build and install kuadrantctl binary ($GOBIN or GOPATH/bin)
+
 .PHONY : install
-install: fmt vet
+install: fmt vet ## Build and install kuadrantctl binary ($GOBIN or GOPATH/bin)
 	@set -e; \
 	GIT_SHA=$$(git rev-parse --short=7 HEAD 2>/dev/null) || { \
 		GIT_HASH=$${GITHUB_SHA:-NO_SHA}; \
@@ -79,28 +66,30 @@ prepare-local-cluster: $(KIND) ## Deploy locally kuadrant operator from the curr
 env-setup:
 	$(MAKE) gateway-api-install
 
-## local-setup: Sets up Kind cluster with GatewayAPI manifests and istio GW, nothing Kuadrant. Build and install kuadrantctl binary
 .PHONY: local-setup
-local-setup:
+local-setup: ## Sets up Kind cluster with GatewayAPI manifests
 	$(MAKE) prepare-local-cluster
 	$(MAKE) env-setup
 
-## local-cleanup: Delete local cluster
 .PHONY: local-cleanup
 local-cleanup: ## Delete local cluster
 	$(MAKE) kind-delete-cluster
 
 .PHONY : fmt
-fmt:
+fmt: ## Run go fmt ./...
 	$(GO) fmt ./...
 
 .PHONY : vet
-vet:
+vet: ## Run go vet ./...
 	$(GO) vet ./...
 
 .PHONY: clean-cov
 clean-cov: ## Remove coverage reports
 	rm -rf $(PROJECT_PATH)/coverage
+
+.PHONY: run-lint
+run-lint: $(GOLANGCI-LINT) ## Run linter tool (golangci-lint)
+	$(GOLANGCI-LINT) run --timeout 2m
 
 # Include last to avoid changing MAKEFILE_LIST used above
 include ./make/*.mk

--- a/make/tools/ginkgo.mk
+++ b/make/tools/ginkgo.mk
@@ -1,0 +1,10 @@
+GINKGO = $(PROJECT_PATH)/bin/ginkgo
+$(GINKGO):
+	# In order to make sure the version of the ginkgo cli installed
+	# is the same as the version of go.mod,
+	# instead of calling go-install-tool,
+	# running go install from the current module will pick version from current go.mod file.
+	GOBIN=$(PROJECT_PATH)/bin go install github.com/onsi/ginkgo/v2/ginkgo
+
+.PHONY: ginkgo
+ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.

--- a/make/tools/kind.mk
+++ b/make/tools/kind.mk
@@ -1,0 +1,7 @@
+KIND = $(PROJECT_PATH)/bin/kind
+KIND_VERSION = v0.22.0
+$(KIND):
+	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@$(KIND_VERSION))
+
+.PHONY: kind
+kind: $(KIND) ## Download kind locally if necessary.

--- a/make/tools/kustomize.mk
+++ b/make/tools/kustomize.mk
@@ -1,0 +1,6 @@
+KUSTOMIZE = $(PROJECT_PATH)/bin/kustomize
+$(KUSTOMIZE):
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.5)
+
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/make/tools/lint.mk
+++ b/make/tools/lint.mk
@@ -1,11 +1,8 @@
+
 GOLANGCI-LINT=$(PROJECT_PATH)/bin/golangci-lint
 $(GOLANGCI-LINT):
 	mkdir -p $(PROJECT_PATH)/bin
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_PATH)/bin v1.55.2
 
 .PHONY: golangci-lint
-golangci-lint: $(GOLANGCI-LINT)
-
-.PHONY: run-lint
-run-lint: $(GOLANGCI-LINT)
-	$(GOLANGCI-LINT) run --timeout 2m
+golangci-lint: $(GOLANGCI-LINT) ## Download golangci-lint 


### PR DESCRIPTION
### What

Some small fixes to the Makefile and make files to have clean `help`

```
make help

Usage:
  make <target>
  help                            Display this help.

Development
  test                            Run unit tests
  install                         Build and install kuadrantctl binary ($GOBIN or GOPATH/bin)
  prepare-local-cluster           Deploy locally kuadrant operator from the current code
  local-setup                     Sets up Kind cluster with GatewayAPI manifests
  local-cleanup                   Delete local cluster
  fmt                             Run go fmt ./...
  vet                             Run go vet ./...
  clean-cov                       Remove coverage reports
  run-lint                        Run linter tool (golangci-lint)
  ginkgo                          Download ginkgo locally if necessary.
  kind                            Download kind locally if necessary.
  kustomize                       Download kustomize locally if necessary.
  golangci-lint                   Download golangci-lint 

Gateway API resources
  gateway-api-install             Install Gateway API CRDs

Kind
  kind-create-cluster             Create the "kuadrantctl-local" kind cluster.
  kind-delete-cluster             Delete the "kuadrantctl-local" kind cluster.
```