### PR TITLE
Topology command:  open svg graph in the user’s preferred application 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ kuadrantctl [command] [subcommand] [flags]
 | ------------ | ---------------------------------------------------------- |
 | `completion` | Generate autocompletion scripts for the specified shell    |
 | `generate`   | Commands related to Kubernetes Gateway API and Kuadrant resource generation from OpenAPI 3.x specifications          |
+| `topology`   | Command related to Kuadrant topology                       |
 | `help`       | Help about any command                                     |
-| `version`    | Print the version number of `kuadrantctl`                    |
+| `version`    | Print the version number of `kuadrantctl`                  |
 
 ### Flags
 
@@ -80,6 +81,29 @@ Generate Gateway API resources from an OpenAPI 3.x specification
 | Subcommand | Description                                      | Flags                             |
 | ---------- | ------------------------------------------------ | --------------------------------- |
 | `httproute`| Generate Gateway API HTTPRoute from OpenAPI 3.0.X| `--oas string` Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required). `-o` Output format: 'yaml' or 'json'. (default "yaml") |
+
+#### `topology`
+
+Export and visualize kuadrant topology
+
+### Usage
+
+```shell
+$ kuadrantctl topology -h
+Export and visualize kuadrant topology
+
+Usage:
+  kuadrantctl topology [flags]
+
+Flags:
+  -d, --dot string         Graphviz DOT output file
+  -h, --help               help for topology
+  -n, --namespace string   Topology's namespace (default "kuadrant-system")
+  -o, --output string      SVG image output file
+
+Global Flags:
+  -v, --verbose   verbose output
+```
 
 ##### `generate kuadrant`
 

--- a/cmd/topology.go
+++ b/cmd/topology.go
@@ -115,7 +115,12 @@ func runTopology(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	openCmd := exec.Command("open", topologySVGOutputFile)
+	externalCommand := "xdg-open"
+	if _, err := exec.LookPath("open"); err == nil {
+		externalCommand = "open"
+	}
+
+	openCmd := exec.Command(externalCommand, topologySVGOutputFile)
 	// pipe the commands output to the applications
 	// standard output
 	openCmd.Stdout = os.Stdout

--- a/cmd/topology.go
+++ b/cmd/topology.go
@@ -25,13 +25,13 @@ var (
 func topologyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "topology",
-		Short: "Read kuadrant topology",
-		Long:  "Read kuadrant topology",
+		Short: "Export and visualize kuadrant topology",
+		Long:  "Export and visualize kuadrant topology",
 		RunE:  runTopology,
 	}
 
 	cmd.Flags().StringVarP(&topologyNS, "namespace", "n", "kuadrant-system", "Topology's namespace")
-	cmd.Flags().StringVarP(&topologyOutputFile, "output", "o", "(required)", "Output file")
+	cmd.Flags().StringVarP(&topologyOutputFile, "output", "o", "", "Output file")
 	err := cmd.MarkFlagRequired("output")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
### What 

topology command: persist in local disk in [DOT](https://graphviz.org/doc/info/lang.html) format and SVG format

```
❯ bin/kuadrantctl topology -h
Export and visualize kuadrant topology

Usage:
  kuadrantctl topology [flags]

Flags:
  -d, --dot string         Graphviz DOT output file
  -h, --help               help for topology
  -n, --namespace string   Topology's namespace (default "kuadrant-system")
  -o, --output string      SVG image output file

Global Flags:
  -v, --verbose   verbose output
```

### Verification steps

* Install kuadrant
```
helm repo add kuadrant https://kuadrant.io/helm-charts/ --force-update
helm install kuadrant kuadrant/kuadrant-operator --namespace kuadrant-system --create-namespace
```
* Deploy kuadrant
```
kubectl -n kuadrant-system apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```
* Export and visualize topology

Compile the tool
```
make install
```
Run the command
```
bin/kuadrantctl topology -o ~/tmp/topology.svg
```