### PR TITLE
add dns plugin

### DIFF
--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+func dnsCommand() *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "dns",
+		Short: "DNS Operator command line utility",
+		Long:  "DNS Operator command line utility",
+		RunE:  runDNS,
+	}
+	return versionCmd
+}
+
+func runDNS(_ *cobra.Command, args []string) error {
+	// pass verbose from root
+	args = append(args, fmt.Sprintf("--verbose=%t", verbose))
+
+	out, err := exec.Command("kubectl-dns", args...).Output()
+	if err != nil {
+		return fmt.Errorf("failed to run dns plugin: %w", err)
+	}
+	fmt.Printf("%s\n", out)
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"context"
 	"os"
+	"os/exec"
 
 	"github.com/spf13/cobra"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -51,5 +52,14 @@ func GetRootCmd(args []string) *cobra.Command {
 	rootCmd.AddCommand(generateCommand())
 	rootCmd.AddCommand(topologyCommand())
 
+	if isBinaryAvailable("kubectl-dns") {
+		rootCmd.AddCommand(dnsCommand())
+	}
+
 	return rootCmd
+}
+
+func isBinaryAvailable(name string) bool {
+	path, err := exec.LookPath(name)
+	return path != "" && err == nil
 }


### PR DESCRIPTION
Use a kubectl plugin from `dns-operator` repo. 
There is a [task](https://github.com/Kuadrant/dns-operator/issues/527) to get the binary, for now it will ask you to do it manually 