### PR TITLE
gh-599 use correct cli name and improve flags handling

### DIFF
--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -14,15 +14,22 @@ func dnsCommand() *cobra.Command {
 		Long:  "DNS Operator command line utility",
 		RunE:  runDNS,
 	}
+
+	// this will pass all flags as args
+	versionCmd.DisableFlagParsing = true
 	return versionCmd
 }
 
 func runDNS(_ *cobra.Command, args []string) error {
-	// pass verbose from root
-	args = append(args, fmt.Sprintf("--verbose=%t", verbose))
 
-	out, err := exec.Command("kubectl-dns", args...).Output()
+	out, err := exec.Command("kubectl-kuadrant_dns", args...).Output()
 	if err != nil {
+		// display help tooltip
+		tooltip, tooltipErr := exec.Command("kubectl-kuadrant_dns", []string{args[0], "--help"}...).Output()
+		if tooltipErr == nil {
+			fmt.Printf("%s\n", tooltip)
+		}
+
 		return fmt.Errorf("failed to run dns plugin: %w", err)
 	}
 	fmt.Printf("%s\n", out)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ func GetRootCmd(args []string) *cobra.Command {
 	rootCmd.AddCommand(generateCommand())
 	rootCmd.AddCommand(topologyCommand())
 
-	if isBinaryAvailable("kubectl-dns") {
+	if isBinaryAvailable("kubectl-kuadrant_dns") {
 		rootCmd.AddCommand(dnsCommand())
 	}
 


### PR DESCRIPTION
use the correct name of the dns cli 

also, i noticed that we are not using flags correctly -  especially the `help` one. Fixed by forcing flags to be passed to the cli 