### PR TITLE
ADD: Plugin Package

### DIFF
--- a/.github/workflows/plugins.yaml
+++ b/.github/workflows/plugins.yaml
@@ -1,0 +1,40 @@
+---
+
+name: Plugins
+
+permissions:
+  contents: write
+  packages: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_reason:
+        description: 'Reason for manual execution'
+        required: false
+        default: 'Manual run by user'
+
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
+
+jobs:
+  run_script_job:
+    if: |
+      github.event_name == 'workflow_dispatch' || 
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+
+    env:
+      AFFECT_RELEASE: "true" 
+      DEBUG: "false"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ORG_NAME: ${{ github.repository_owner }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Run Bash Script
+        run: |
+          bash scripts/plugins

--- a/README.md
+++ b/README.md
@@ -9,21 +9,25 @@
 
 ### Installing Pre-compiled Binaries
 
-1. Download the latest binary for your platform from the [`kuadrantctl` Releases](https://github.com/Kuadrant/kuadrantctl/releases) page.
-2. Unpack the binary.
-3. Move it to a directory in your `$PATH` so that it can be executed from anywhere.
+1. Download the latest binary package for your platform from the [`kuadrantctl` Releases](https://github.com/Kuadrant/kuadrantctl/releases) page.
+2. Unpack the archive. This will extract two binaries:
+   - `kuadrantctl` - the main CLI tool
+   - `kubectl-kuadrant_dns` - the DNS operator plugin
+3. Move **both binaries** to a directory in your `$PATH` so that they can be executed from anywhere.
+
+**Note:** Both binaries are required for full functionality. The DNS plugin is invoked through the `kuadrantctl dns` command.
 
 ### Compiling from Source
 
-If you prefer to compile from source or are contributing to the project, you can install `kuadrantctl` using  `make install`. This method requires Golang 1.23.6 or newer.
+If you prefer to compile from source or are contributing to the project, you can install `kuadrantctl` using `make install`. This method requires Golang 1.23.6 or newer.
 
-It is possible to use the make target `install` to compile from source. From root of the repository, run 
+It is possible to use the make target `install` to compile from source. From root of the repository, run
 
 ```bash
 make install
 ```
 
-This will compile `kuadrantctl` and install it in the `bin` directory at root of directory. It will also ensure the correct version of the binary is displayed . It can be ran using `./bin/kuadrantctl` .  
+This will compile `kuadrantctl` and install it in the `bin` directory at root of directory. It will also ensure the correct version of the binary is displayed. It can be ran using `./bin/kuadrantctl`.  
 
 ## Usage
 

--- a/scripts/plugins
+++ b/scripts/plugins
@@ -1,0 +1,233 @@
+#! /usr/bin/env bash
+
+echo "Running plugin packaging"
+
+ORG="${ORG_NAME:-Kuadrant}"
+CTL=$ORG/kuadrantctl
+PLUGINS=($ORG/dns-operator)
+
+echo "target repo: $CTL"
+echo "plugins"
+for plugin in "${PLUGINS[@]}"; do
+  echo "- $plugin"
+done
+echo
+if [ "$AFFECT_RELEASE" = "true" ]; then
+    echo "Updating release: YES"
+else
+    echo "Updating release: NO"
+    echo "Set AFFECT_RELEASE=true to update release"
+fi
+echo
+
+# -----
+# Set up workspace
+#
+
+INITIAL_LOCATION=$(pwd)
+
+download() {
+    data="$1"
+
+    echo "Get $data release data"
+
+    API_URL="https://api.github.com/repos/${data}/releases/latest"
+    echo "Fetching latest release data for ${data}..."
+    echo "API Endpoint: $API_URL"
+    marker
+
+    RELEASE_DATA=$(curl \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -s "$API_URL")
+    if echo "$RELEASE_DATA" | grep -q "Not Found"; then
+        echo "ERROR: Repository or latest release not found." >&2
+        exit 1
+    fi
+
+    VERSION=$(echo "$RELEASE_DATA" | jq -r '.tag_name')
+
+    echo "$plugin: $VERSION" 
+    ASSET_LIST=$(echo "$RELEASE_DATA" | jq -r '.assets[] | "\(.name)\t\(.browser_download_url)"')
+
+    # Set IFS to tab for separation
+    while IFS=$'\t' read -r asset_name asset_url; do
+        if [[ "$asset_name" == *".tar.gz" ]]; then
+            echo "Asset Name: $asset_name"
+            echo "Download URL: $asset_url"
+            asset_path="$TMP_DIR/$data/$asset_name"
+            echo "Downloading..."
+            curl \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                -L "$asset_url" -o "$asset_path"
+            if [ $? -ne 0 ]; then
+                echo "Error: Failed to download: $asset_url." >&2
+                exit 1
+            fi
+
+            echo "Extracting..."
+            IFS='-' read -ra temp <<< "$asset_name"
+            temp1="${temp[-2]}-${temp[-1]}"
+            arch="${temp1%%.*}"
+            tar -xzf "$asset_path" -C "$TMP_DIR/binaries/$arch"
+            if [ $? -ne 0 ]; then
+                echo "Error: Failed to extract: $asset_path." >&2
+                exit 1
+            fi
+            marker
+        fi
+    done <<< "$ASSET_LIST"
+}
+
+marker() {
+    echo "-----------------------------------"
+}
+
+cleanup() {
+    cd "$INITIAL_LOCATION"
+    if [ -z "$TMP_DIR" ]; then
+        return 0
+    fi
+    if [ "$DEBUG" = "true" ]; then
+        echo
+        echo "DEBUG MODE: Temporary directory cleanup is DISABLED."
+        echo "Directory contents left for inspection: $TMP_DIR"
+        echo "To remove it manually: rm -rf \"$TMP_DIR\""
+    else
+        if [ -d "$TMP_DIR" ]; then
+            echo "Cleaning up temporary directory: $TMP_DIR"
+            rm -rf "$TMP_DIR"
+        fi
+    fi
+}
+
+trap cleanup EXIT HUP INT QUIT TERM
+
+TMP_DIR=$(mktemp -d -t kuadrantctl.XXXXXXXXXX)
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to create temporary directory." >&2
+    exit 1
+fi
+
+mkdir -p $TMP_DIR/archives/
+mkdir -p $TMP_DIR/$CTL/
+mkdir -p $TMP_DIR/binaries/{darwin-amd64,linux-amd64,darwin-arm64,linux-arm64}
+for plugin in "${PLUGINS[@]}"; do
+    mkdir -p $TMP_DIR/$plugin/
+done
+
+echo "Created temporary directory: $TMP_DIR"
+marker
+
+# -----
+echo "Get $CTL version"
+
+API_URL="https://api.github.com/repos/${CTL}/releases/latest"
+echo "Fetching latest release data for ${CTL}..."
+echo "API Endpoint: $API_URL"
+marker
+
+RELEASE_DATA=$(curl \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    -s "$API_URL")
+if echo "$RELEASE_DATA" | grep -q "Not Found"; then
+    echo "ERROR: Repository or latest release not found." >&2
+    exit 1
+fi
+
+CTL_VERSION=$(echo "$RELEASE_DATA" | jq -r '.tag_name')
+echo "$CTL version: $CTL_VERSION"
+CTL_ID=$(echo "$RELEASE_DATA" | jq -r '.id')
+echo "$CTL id: $CTL_ID"
+marker
+
+# download require files
+download "$CTL"
+for plugin in "${PLUGINS[@]}"; do
+    download "$plugin"
+done
+
+echo "Creating archives"
+while read -r dir; do
+    tar_file="../../archives/kuadrantctl-$CTL_VERSION-$dir.tar.gz"
+    echo "Creating archive for : $dir"
+    cd "$TMP_DIR/binaries/$dir"
+    touch "$tar_file"
+    tar -czvf "$tar_file" .
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to create tar.gz : $tar_file" >&2
+        exit 1
+    fi
+done <<< "$(ls $TMP_DIR/binaries)"
+marker
+
+echo "Generating MD5 files..."
+cd "$TMP_DIR/archives"
+for file in *.tar.gz; do 
+    md5sum "$file" > "$file".md5 
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to generate MD5 file foe $file" >&2
+        exit 1
+    fi
+done
+marker
+
+echo "Update release assets in GitHub for $CTL"
+ASSETS=$(curl -L \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/$CTL/releases/$CTL_ID/assets" \
+  )
+
+ASSETS=$(echo $ASSETS | jq -r '.[] | "\(.name)\t\(.url)"')
+
+while IFS=$'\t' read -r name url; do
+
+    file="$TMP_DIR/archives/$name"
+    echo "checking file: $file"
+    if [ -f "$file" ]; then
+        echo "Resouce to update: $name, $url"
+
+        if [ "$AFFECT_RELEASE" = "true" ]; then
+            echo "Deleting: $name"
+            curl -L \
+              -X DELETE \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$url"
+            if [ $? -ne 0 ]; then
+                echo "Error: deleting existing resource from release" >&2
+                exit 1
+            fi
+
+            echo "Uploading new version: $name"
+            curl -L \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -H "Content-Type: application/octet-stream" \
+              "https://uploads.github.com/repos/$CTL/releases/$CTL_ID/assets?name=$name" \
+              --data-binary "@$file"
+            if [ $? -ne 0 ]; then
+                echo "Error: Uploading new resource" >&2
+                exit 1
+            fi
+
+        else
+            echo "NOT UPDATING RELEASE"
+            echo "Set AFFECT_RELEASE=true to update release"
+            echo "Deleting: $name"
+            echo "Uploading new version: $name"
+        fi
+    fi
+done <<< "$ASSETS"
+
+echo -e "\nCOMPLETE"


### PR DESCRIPTION
Release processes updated by adding new workflow to bundle plugins with the kuadrantctl.

The script rebuilds the tar.gz archives to include the binaries for the plugins.
Currently the only plugin comes from the DNS-operator. The md5 hash is recreated. 

To update the artifacts in a release the initial resources need to be removed before the new resources can be added.

The script requires the following envs:

|EnvVar|type|default|description|
|-|-|-|-|
|GITHUB_TOKEN|string|<not set>| requires "Contents" repository permissions (write)|
|DEBUG|bool "true\|false"|false|When set to true the script will not clean up the temporary file structure which was created during a run.|
|AFFECT_RELEASE|bool "true\|false"|false|When set to true will update release.|
|ORG_NAME|string|kuadrant|Used to set the org where the release exists. Allow running workflow on forks.|

## Examples

These examples were all done from my forks.

Base dns-operator release: https://github.com/Boomatang/dns-operator/releases/tag/v0.16.0
kuadrantctl release: https://github.com/Boomatang/kuadrantctl/releases/tag/v0.16.0
Manual trigger of plugin workflow: https://github.com/Boomatang/kuadrantctl/actions/runs/19862790262
Release tringgered workflow (contained org error) : https://github.com/Boomatang/kuadrantctl/actions/runs/19862402720

The artifacts attached to the release contains the two binaries, and the md5 checksum has being updated. 

