### PR TITLE
MULTIARCH-5995: add ppc64le support to the build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,9 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64
+        # build and publish in parallel: linux/amd64, linux/arm64, linux/ppc64le, darwin/amd64, darwin/arm64
         goos: [linux, darwin]
-        goarch: [amd64, arm64]
+        goarch: [amd64, arm64, ppc64le]
+        exclude:
+          - goos: darwin
+            goarch: ppc64le
     steps:
     - uses: actions/checkout@v4
     - uses: wangyoucao577/go-release-action@v1

--- a/doc/kuadrantctl-ci-cd.md
+++ b/doc/kuadrantctl-ci-cd.md
@@ -80,6 +80,7 @@ spec:
         x86_64) BIN_ARCH="amd64";;
         arm64) BIN_ARCH="arm64";;
         aarch64) BIN_ARCH="arm64";;
+        ppc64le) BIN_ARCH="ppc64le";;
         *) echo "Unsupported architecture: $ARCH" && exit 1 ;;
         esac
         cd $(workspaces.source.path)

--- a/scripts/plugins
+++ b/scripts/plugins
@@ -114,7 +114,7 @@ fi
 
 mkdir -p $TMP_DIR/archives/
 mkdir -p $TMP_DIR/$CTL/
-mkdir -p $TMP_DIR/binaries/{darwin-amd64,linux-amd64,darwin-arm64,linux-arm64}
+mkdir -p $TMP_DIR/binaries/{darwin-amd64,linux-amd64,darwin-arm64,linux-arm64,linux-ppc64le}
 for plugin in "${PLUGINS[@]}"; do
     mkdir -p $TMP_DIR/$plugin/
 done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added support for the `ppc64le` architecture in build and deployment pipelines alongside existing `amd64` and `arm64` platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrantctl/pull/122)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->